### PR TITLE
ci: GitHub Actions unit tests and deploy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,24 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v
+
   deploy:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Run remote deploy hook

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ python -m unittest discover -s tests -v
 
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) — структура, UI (Bootstrap 5), IronBee (Chrome + CDP), миграции, права
 - [docs/DEPLOY.md](docs/DEPLOY.md) — PythonAnywhere **Beginner**, `.env`, auto-deploy при push в `main`
-- [CHANGELOG](https://github.com/discipleartem/flask_blog/releases) — релизы
+- [docs/CHANGELOG.md](docs/CHANGELOG.md) — история изменений
 
 ## Ветки
 

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -4,6 +4,22 @@
 
 Синхронизация с [GitHub Project «Flask Blog»](https://github.com/users/discipleartem/projects/6): `python ~/.cursor/skills/backlog-github-projects-sync/scripts/sync_backlog.py` (конфиг [`.github/backlog.json`](../.github/backlog.json)).
 
+## CI + gate для deploy (PythonAnywhere Beginner)
+
+**Статус:** in_review
+**GitHub:** #41
+
+### Проблема
+
+CD на PythonAnywhere уже есть (`deploy.yml` + hook `/internal/deploy`), но в GitHub Actions нет отдельного CI: unit-тесты не гоняются на PR/`push`, а деплой на `main` не защищён проверкой перед hook/reload.
+
+### Acceptance criteria
+
+- Workflow CI: Python **3.12**, `pip install -r requirements.txt`, `python -m unittest discover -s tests -v` на `push`/`pull_request` в `main` и `dev`.
+- В `deploy.yml` job `deploy` (hook + PA API reload) выполняется только после успешного job `test`.
+- Документация: `DEVELOPMENT.md`, `DEPLOY.md`, `CHANGELOG.md` отражают CI и gate.
+- Секреты PA и схема деплоя Beginner (без SSH) не меняются.
+
 ## Улучшение UI при регистрации/авторизации
 
 **Статус:** done

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Added
 
+- GitHub Actions CI: unit-тесты (Python 3.12) на `push`/`pull_request` в `main` и `dev` (`.github/workflows/ci.yml`).
+- Deploy на PythonAnywhere gated: job `deploy` после успешного `test` в `.github/workflows/deploy.yml`.
 - Страница успешной регистрации с полным логином `name#NNNN` и сохранением учётки через Credential Management API (`PasswordCredential`), чтобы менеджер паролей предлагал полный тег, а не только имя без дискриминатора.
 - Регистрация через `fetch` (XHR), чтобы Chrome не предлагал сохранить неполный username из HTML-формы.
 - Unit-тесты на страницу успеха регистрации и поле входа `username`.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -229,7 +229,9 @@ Workflow: [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml).
   PR / squash-merge в main
             │
             ▼
-  GitHub Actions (push: main)
+  GitHub Actions (push: main) — deploy.yml
+            │
+            ├─ 0. unittest (Python 3.12); при падении deploy не запускается
             │
             ├─ 1. POST https://PA_DOMAIN/internal/deploy
             │      Authorization: Bearer DEPLOY_SECRET
@@ -241,6 +243,8 @@ Workflow: [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml).
                    Authorization: Token PA_API_TOKEN
                    worker подхватывает новый код
 ```
+
+Отдельно CI без деплоя: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) на `push`/`pull_request` в `main` и `dev`.
 
 Триггеры workflow:
 
@@ -314,10 +318,10 @@ echo "$PYTHONANYWHERE_SITE"
 
 ### Релизный цикл (день за днём)
 
-1. Фичи мержатся в `dev`, тестируются.
+1. Фичи мержатся в `dev`, тестируются (CI `ci.yml` на PR/push).
 2. PR `dev` **→** `main` (обычно squash merge) → push в `main`.
-3. Actions запускает **Deploy to PythonAnywhere**.
-4. В логе job: ответ hook (JSON со `steps`) и строка `Reload requested`.
+3. Actions запускает **Deploy to PythonAnywhere**: сначала job `test`, затем hook + reload.
+4. В логе job `deploy`: ответ hook (JSON со `steps`) и строка `Reload requested`.
 5. Откройте сайт и пробегитесь по [Smoke-чеклисту](#smoke-чеклист).
 
 Ручной прогон без merge: Actions → **Deploy to PythonAnywhere** → **Run workflow**.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,12 +34,16 @@ Integration: `dev`. Релиз: `main`. Task-ветки: `feat/…`, `docs/…`,
 
 ## Проверка
 
-**Автоматически (агент / CI):** только unit-тесты:
+**Автоматически (агент / CI):** только unit-тесты.
+
+Локально:
 
 ```bash
 source .venv/bin/activate
 python -m unittest discover -s tests -v
 ```
+
+В GitHub Actions: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) на `push`/`pull_request` в `main` и `dev`. Деплой на PythonAnywhere ([`deploy.yml`](../.github/workflows/deploy.yml)) на `main` идёт только после успешного того же прогона.
 
 **Вручную в браузере** (по необходимости, в т.ч. auth / password manager): регистрация → **Save** на ключике с полным `name#NNNN` → logout → login через предложение браузера (autofill). Агент не гоняет Playwright/CDP-скрипты для этого.
 
@@ -107,7 +111,7 @@ app/
 migrations/        # numbered *.sql
 schema.sql         # source of truth
 .env.example       # шаблон секретов (реальный .env в .gitignore)
-.github/workflows/ # deploy.yml — push main → PA
+.github/workflows/ # ci.yml (unittest); deploy.yml — push main → PA (после test)
 .vscode/
   settings.json    # IronBee CDP, Python interpreter, terminal+venv
   launch.json      # debugpy → flask run


### PR DESCRIPTION
## Summary
- Add CI workflow (Python 3.12 + unittest) on push/PR to `main` and `dev`.
- Gate PythonAnywhere deploy: hook + reload only after successful `test` job.
- Document CI/deploy gate; backlog task #41 → in_review.

## Test plan
- [ ] CI workflow runs green on this PR
- [ ] Review `ci.yml` and `deploy.yml` (job `needs: test`)
- [ ] After merge to `main` later: deploy still runs only if tests pass

Closes #41


Made with [Cursor](https://cursor.com)