### PR TITLE
docs: mark CI backlog task done after merge

### DIFF
--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -6,7 +6,7 @@
 
 ## CI + gate для deploy (PythonAnywhere Beginner)
 
-**Статус:** in_review
+**Статус:** done
 **GitHub:** #41
 
 ### Проблема


### PR DESCRIPTION
## Summary
- Backlog #41 → `done` after merge of #42 into `dev`.

## Test plan
- [ ] Project card for #41 in Done


Made with [Cursor](https://cursor.com)