### PR TITLE
docs: mark markdown editor backlog task done after merge

### DIFF
--- a/.cursor/rules/git-merged-branches.mdc
+++ b/.cursor/rules/git-merged-branches.mdc
@@ -1,5 +1,5 @@
 ---
-description: После merge task-ветки на GitHub — переименовать в merged/*, не удалять
+description: После merge task-ветки на GitHub — переименовать в merged/*, вернуться на dev
 alwaysApply: true
 ---
 
@@ -14,29 +14,49 @@ alwaysApply: true
 1. **Не** удалять ветку на GitHub «в никуда» (кнопка Delete branch / `git push --delete` без архива).
 2. **Переименовать** в `merged/<короткое-имя>` локально **и** на `origin`.
 3. Архив `merged/*` **хранится на GitHub** — это норма для этого репозитория.
+4. **Обязательно** закончить на integration-ветке: `git checkout dev && git pull --ff-only origin dev` (для merge в `main` — `main`). Не оставлять checkout на task-ветке, `docs/*` follow-up или `merged/*`.
 
 Имена: `feat/foo` → `merged/foo`, `docs/bar` → `merged/bar` (префикс `feat/` / `docs/` / … снимается, остаётся kebab-case имя задачи).
 
-## Процедура (агент)
+## Алгоритм агента (после «merged» / PR `MERGED`)
 
-```bash
-# на task-ветке после merge (или с локальной копией tip)
-git branch -m feat/my-task merged/my-task
-git push -u origin merged/my-task
-git push origin --delete feat/my-task   # только старое имя; tip уже на merged/*
-```
-
-Если локальной ветки нет, а remote ещё `origin/feat/my-task`:
+Выполнять **в одном turn**, порядок фиксирован:
 
 ```bash
 git fetch origin
-git branch merged/my-task origin/feat/my-task
-git push -u origin merged/my-task
-git push origin --delete feat/my-task
+INTEGRATION=dev   # или main, если merge был в main
+TASK=feat/my-task # head PR до merge
+SHORT=my-task     # без префикса feat|/docs|/fix|/chore|
+
+# 1) Сначала на integration (rename чужой ветки удобнее не с неё)
+git checkout "$INTEGRATION"
+git pull --ff-only origin "$INTEGRATION"
+
+# 2) Локальный rename (+ remote archive)
+if git show-ref --verify --quiet "refs/heads/$TASK"; then
+  git branch -m "$TASK" "merged/$SHORT"
+else
+  git branch "merged/$SHORT" "origin/$TASK"   # если локальной уже нет
+fi
+git push -u origin "merged/$SHORT"
+git push origin --delete "$TASK"             # только старое имя; tip уже на merged/*
+
+# 3) Конечное состояние сессии — снова integration
+git checkout "$INTEGRATION"
+git status -sb   # должна быть ## dev...origin/dev (или main)
 ```
+
+### Follow-up (backlog `done` / docs)
+
+Если после merge нужен отдельный PR (`docs/…-backlog-done`):
+
+1. Создать ветку **от актуального `dev`**, коммит, push, `gh pr create --base dev`.
+2. **Сразу после push/PR:** `git checkout dev` — не оставлять пользователя на `docs/…`.
+3. Когда этот docs-PR смержен — снова полный алгоритм выше (`docs/foo` → `merged/foo`, checkout `dev`).
 
 ## Запрещено
 
 - Удалять remote task-ветку после merge без создания `origin/merged/…`
 - Делать PR / открывать новую работу с head `merged/…` (архив только для истории)
 - Force-push в `main` / `dev`
+- Завершать post-merge turn, оставаясь на task / `docs/*` / `merged/*` вместо `dev` (или `main`)

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -4,22 +4,3 @@
 Выполненные задачи фиксируются в [`CHANGELOG.md`](CHANGELOG.md) и из этого файла удаляются.
 
 Синхронизация с [GitHub Project «Flask Blog»](https://github.com/users/discipleartem/projects/6): `python ~/.cursor/skills/backlog-github-projects-sync/scripts/sync_backlog.py` (конфиг [`.github/backlog.json`](../.github/backlog.json)).
-
-## Markdown-редактор для Post и Comment
-
-**Статус:** in_review
-**GitHub:** #44
-
-### Проблема
-
-Сейчас текст поста и комментария вводится как plain text без форматирования. Пользователям нужен web-редактор Markdown, чтобы размечать текст (заголовки, списки, ссылки, выделение и т.п.) при создании и редактировании Post и Comment.
-
-### Acceptance criteria
-
-- На формах создания/редактирования Post подключён Markdown-редактор EasyMDE (vendor в static, не CDN; JS обязателен для редактора).
-- На формах создания/редактирования Comment — тот же подход.
-- Канон в БД: `body_source` + `body_format`; для этих форм сервер всегда сохраняет `body_format=markdown` (клиентский format игнорируется).
-- Витрина: HTML через серверный `render_to_html` + санитизация XSS (nh3); не сырой Markdown и не `| safe` по колонке из БД.
-- Preview в тулбаре EasyMDE через `POST /markdown/preview` (тот же серверный рендер, что на витрине).
-- Подсветка fenced-блоков на витрине/preview (`syntax-highlight.js`: python/html/js/css/bash + generic); автоотступы; кнопки копирования plain и Markdown с тостом.
-- UI согласован с Bootstrap 5; без React/Vue и прочих SPA-фреймворков.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Docs
 
+- Backlog #44 (Markdown-редактор) закрыт после merge в `dev` (#45).
 - `DEVELOPMENT.md`: контент Markdown (рендер, preview, подсветка, копирование кода), структура `content_render` / static JS.
 - `SESSION_COOKIE_SECURE` для HTTPS-деплоя (`.env.example`, `DEPLOY.md`).
 - Уточнён приоритет окружения над `.env` при `load_dotenv` (уже заданные переменные процесса не перезаписываются).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -57,7 +57,7 @@ Custom CSS (`app/static/css/app.css`) и JS (`theme.js`, `markdown-editor.js`, `
 
 Integration: `dev`. Релиз: `main`. Task-ветки: `feat/…`, `docs/…`, …
 
-После merge PR **не удалять** ветку на GitHub без архива: переименовать в `merged/<имя>` локально и на `origin` (канон для агента: [`.cursor/rules/git-merged-branches.mdc`](../.cursor/rules/git-merged-branches.mdc)).
+После merge PR **не удалять** ветку на GitHub без архива: переименовать в `merged/<имя>` локально и на `origin`, затем **checkout `dev`** (канон: [`.cursor/rules/git-merged-branches.mdc`](../.cursor/rules/git-merged-branches.mdc)).
 
 ## Проверка
 


### PR DESCRIPTION
## Summary
- Backlog #44 → `done` after merge of #45 into `dev`; section removed from `Backlog.md`.
- Archive branch: `merged/markdown-editor` (old `feat/markdown-editor` deleted on origin).

## Test plan
- [ ] Project card for #44 in Done; issue #44 closed


Made with [Cursor](https://cursor.com)