### PR TITLE
docs: close backlog #51 after UI theme merge

### DIFF
--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -4,22 +4,3 @@
 Выполненные задачи фиксируются в [`CHANGELOG.md`](CHANGELOG.md) и из этого файла удаляются.
 
 Синхронизация с [GitHub Project «Flask Blog»](https://github.com/users/discipleartem/projects/6): `python ~/.cursor/skills/backlog-github-projects-sync/scripts/sync_backlog.py` (конфиг [`.github/backlog.json`](../.github/backlog.json)).
-
-## Обновление дизайна сайта
-
-**Статус:** in_review
-**GitHub:** #51
-
-### Проблема
-
-Текущий UI выглядит устаревшим / шаблонным. Нужно обновить визуальный дизайн сайта, опираясь **только на Bootstrap 5** (серверные Jinja-шаблоны + CSS проекта). Без front-end фреймворков (React, Vue и т.п.), без смены стека UI.
-
-### Acceptance criteria
-
-- Дизайн обновлён с использованием компонентов и утилит Bootstrap 5; кастомный CSS минимален и не дублирует то, что даёт Bootstrap.
-- Обновлены ключевые поверхности: layout/навигация, лента постов, страница поста, формы (login / комментарии / редактирование), админские экраны пользователей (если затронуты общим layout).
-- Сохранена текущая структура маршрутов и разметки логики (auth, CSRF, права) — меняется только представление.
-- Тема и типографика согласованы между страницами; адаптив (mobile / desktop) работает.
-- Нет подключения React/Vue/Angular/Svelte и аналогов; UI остаётся Jinja2 + Bootstrap 5.
-- CHANGELOG (Unreleased / Changed или Docs) отражает обновление дизайна.
-- Sync backlog ↔ GitHub Project выполнен (`**GitHub:** #N` в секции).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Docs
 
+- Backlog #51 (обновление дизайна warm/chrome UI) выполнен и удалён из `Backlog.md` после merge в `dev`.
 - Skill `flask-blog-git-release-sync`: синхронизация `dev` ← `main` после релиза (конфликты CHANGELOG/version — в пользу `main`).
 - DEVELOPMENT §UI / §Контент, ARCHITECTURE и `ui-bootstrap.mdc`: warm/chrome dual theme, лента/комментарии, фильтр `plain_excerpt`.
 - Gate: skill `flask-blog-docs-after-task` обязателен перед PR task → `dev` (порядок docs → verify → push → PR); обновлены `00-project`, `docs-context`, `backlog-status`, `task-cycle`, `git-commit-pr`.


### PR DESCRIPTION
## Summary
- Mark GitHub Project / issue #51 Done and remove the section from `Backlog.md`
- Note completion in CHANGELOG Docs

## Test plan
- [ ] Backlog.md has no «Обновление дизайна сайта» section
- [ ] Project issue #51 is Done


Made with [Cursor](https://cursor.com)