### PR TITLE
docs: GitHub Projects API and auth security backlog

### DIFF
--- a/.cursor/rules/backlog-status.mdc
+++ b/.cursor/rules/backlog-status.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # Backlog status
 
-Канон: [`docs/Backlog.md`](../../docs/Backlog.md) · sync: skill `backlog-github-projects-sync` · map: [`.github/backlog.json`](../../.github/backlog.json).
+Канон: [`docs/Backlog.md`](../../docs/Backlog.md) · sync: skill `backlog-github-projects-sync` · map: [`.github/backlog.json`](../../.github/backlog.json) · API: [`docs/GITHUB-PROJECTS-API.md`](../../docs/GITHUB-PROJECTS-API.md).
 
 Ключи `**Статус:**` → колонка Project:
 
@@ -15,8 +15,9 @@ alwaysApply: false
 | `open` | Backlog |
 | `in_progress` | In progress |
 | `in_review` | In review |
-| `ready` | Ready |
 | `done` | Done |
+
+Опционально `**Приоритет:**` / `**Priority:**` → поле Project **Priority** (`P0` / `P1` / `P2` на доске №6; `priorityMap` в `.github/backlog.json`).
 
 ## Когда менять (агент)
 

--- a/.github/backlog.json
+++ b/.github/backlog.json
@@ -8,8 +8,12 @@
     "open": "Backlog",
     "in_progress": "In progress",
     "in_review": "In review",
-    "ready": "Ready",
     "done": "Done"
+  },
+  "priorityMap": {
+    "p0": "P0",
+    "p1": "P1",
+    "p2": "P2"
   },
   "labels": ["backlog", "ui", "auth"]
 }

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -4,3 +4,206 @@
 Выполненные задачи фиксируются в [`CHANGELOG.md`](CHANGELOG.md) и из этого файла удаляются.
 
 Синхронизация с [GitHub Project «Flask Blog»](https://github.com/users/discipleartem/projects/6): `python ~/.cursor/skills/backlog-github-projects-sync/scripts/sync_backlog.py` (конфиг [`.github/backlog.json`](../.github/backlog.json)).
+
+Приоритеты доски (single select **Priority**): **`P0`** (критично) · **`P1`** (важно) · **`P2`** (низкий / продукт). Статусы: см. [GITHUB-PROJECTS-API.md](GITHUB-PROJECTS-API.md) и [backlog-status.mdc](../.cursor/rules/backlog-status.mdc).
+
+Каждая задача — заголовок `## …` (одна GitHub Issue). Подзадачи — чеклисты внутри секции. Категория — поле `**Категория:**`.
+
+---
+
+## Auth: CSRF на все mutating POST
+
+**Статус:** open
+**GitHub:** #54
+**Приоритет:** P0
+**Категория:** Auth / Security
+
+### Проблема
+
+CSRF-токен и `validate_csrf()` есть только на login/register. Формы постов, комментариев и users (create/edit/delete) без серверной проверки. Logout через GET без CSRF. `SameSite=Lax` смягчает риск, но не заменяет CSRF на state-changing endpoints.
+
+### Acceptance criteria
+
+- Все mutating POST (posts, comments, users) принимают и проверяют CSRF.
+- Шаблоны форм содержат скрытое поле CSRF (или эквивалент).
+- Unit-тесты: отказ без токена / с неверным токеном.
+
+### Подзадачи
+
+- [ ] CSRF на CRUD постов
+- [ ] CSRF на CRUD комментариев
+- [ ] CSRF на admin users CRUD
+- [ ] Logout перевести на POST + CSRF (убрать GET-logout или оставить redirect-only без side-effect)
+
+---
+
+## Auth: безопасный redirect `next` после login
+
+**Статус:** open
+**GitHub:** #55
+**Приоритет:** P0
+**Категория:** Auth / Security
+
+### Проблема
+
+После login используется `redirect(next_url)` без валидации — риск open redirect. Нужны только relative path / same-host.
+
+### Acceptance criteria
+
+- `next` принимается только если это безопасный относительный путь (или same-host URL по явной политике).
+- Внешние и `//…` URL отклоняются; fallback на безопасный default (например home).
+- Unit-тесты на допустимые и недопустимые значения `next`.
+
+### Подзадачи
+
+- [ ] Хелпер валидации `next` (whitelist relative)
+- [ ] Подключить в login view
+- [ ] Тесты open-redirect negatives
+
+---
+
+## Auth: rate limit / backoff на login
+
+**Статус:** open
+**GitHub:** #56
+**Приоритет:** P1
+**Категория:** Auth / Abuse prevention
+
+### Проблема
+
+`/auth/login` не ограничен — возможен brute-force по паролю.
+
+### Acceptance criteria
+
+- При серии неудачных попыток с одного IP (и/или login) включается задержка или временная блокировка.
+- Успешный login сбрасывает счётчик для субъекта.
+- Поведение задокументировано в DEVELOPMENT / ARCHITECTURE (кратко).
+
+### Подзадачи
+
+- [ ] Выбрать механизм (in-memory / SQLite bucket — без новой СУБД)
+- [ ] Применить к login POST
+- [ ] Unit-тесты на порог и сброс
+
+---
+
+## Auth: не грузить `password_hash` в `g.user`
+
+**Статус:** open
+**GitHub:** #57
+**Приоритет:** P1
+**Категория:** Auth / Hardening
+
+### Проблема
+
+`load_logged_in_user` делает `SELECT *`, поэтому `password_hash` оказывается в request context на каждый запрос (лишние данные; риск утечки в шаблоны при ошибке).
+
+### Acceptance criteria
+
+- Запрос пользователя для `g.user` не выбирает `password_hash`.
+- Login по-прежнему читает хеш только в auth view.
+- Существующие auth/unit-тесты зелёные.
+
+### Подзадачи
+
+- [ ] Явный список колонок в `load_logged_in_user`
+- [ ] Проверить, что шаблоны/хелперы не зависят от лишних полей
+
+---
+
+## Auth: ужесточить политику пароля
+
+**Статус:** open
+**GitHub:** #58
+**Приоритет:** P1
+**Категория:** Auth / Hardening
+
+### Проблема
+
+Минимум 6 символов без требований к сложности / словарям.
+
+### Acceptance criteria
+
+- Задана явная политика (длина и/или классы символов) на register и смене пароля (если есть).
+- Сообщения об ошибке не раскрывают лишнюю информацию о существующих пользователях.
+- Unit-тесты на отказ слабых паролей.
+
+### Подзадачи
+
+- [ ] Правила валидации + константы/конфиг
+- [ ] UI-подсказка в форме регистрации
+- [ ] Тесты
+
+---
+
+## Auth: явный TTL сессии
+
+**Статус:** open
+**GitHub:** #59
+**Приоритет:** P1
+**Категория:** Auth / Session
+
+### Проблема
+
+`session.permanent = True` без явной политики TTL (дефолт Flask ~31 день). Нет разделения «remember me» vs короткий idle timeout.
+
+### Acceptance criteria
+
+- В config задан явный `PERMANENT_SESSION_LIFETIME` (или эквивалент).
+- Поведение описано в docs (DEVELOPMENT / ARCHITECTURE).
+- По возможности — опция короткой сессии без permanent (если UX позволит).
+
+### Подзадачи
+
+- [ ] Константа TTL в config
+- [ ] Документация
+- [ ] (Опционально) remember-me checkbox
+
+---
+
+## Ops: безопасные дефолты SECRET_KEY / ADMIN_PASSWORD
+
+**Статус:** open
+**GitHub:** #60
+**Приоритет:** P0
+**Категория:** Ops / Deploy security
+
+### Проблема
+
+Дефолты `SECRET_KEY="dev-change-me"` и `ADMIN_PASSWORD="admin"` опасны при забытом `.env` на проде.
+
+### Acceptance criteria
+
+- В non-debug / production режиме приложение отказывается стартовать с известными небезопасными дефолтами **или** явно логирует hard fail.
+- DEPLOY.md напоминает обязательность `.env`.
+- Локальный dev с дефолтами по-прежнему удобен.
+
+### Подзадачи
+
+- [ ] Guard при старте factory (prod)
+- [ ] Обновить DEPLOY.md / DEVELOPMENT.md
+- [ ] Тест на отказ с bad defaults в prod-like config
+
+---
+
+## Auth (продукт): password reset / 2FA / роли
+
+**Статус:** open
+**GitHub:** #61
+**Приоритет:** P2
+**Категория:** Auth / Product
+
+### Проблема
+
+Нет сброса пароля, email-verify, 2FA; роль только `is_admin`. Для учебного блога ожидаемо; брать в работу только при реальной потребности.
+
+### Acceptance criteria
+
+- Перед реализацией — отдельное решение «нужно ли» (не делать «на будущее»).
+- Если делается: минимальный вертикальный срез с тестами и docs.
+
+### Подзадачи
+
+- [ ] (Опционально) password reset flow
+- [ ] (Опционально) 2FA
+- [ ] (Опционально) роли шире admin/user — только с обоснованием

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ### Docs
 
+- `docs/GITHUB-PROJECTS-API.md`: возможности Projects v2, GraphQL/REST/`gh`, маппинг Status/Priority на backlog.
+- Backlog: auth/security задачи из обзора (CSRF, `next`, rate limit, session, пароли, prod defaults) с Priority P0–P2; sync → issues #54–#61 на Project «Flask Blog».
+- `backlog.json` / `backlog-status.mdc`: поле Priority; статус `ready` убран из `statusMap`.
 - Backlog #51 (обновление дизайна warm/chrome UI) выполнен и удалён из `Backlog.md` после merge в `dev`.
 - Skill `flask-blog-git-release-sync`: синхронизация `dev` ← `main` после релиза (конфликты CHANGELOG/version — в пользу `main`).
 - DEVELOPMENT §UI / §Контент, ARCHITECTURE и `ui-bootstrap.mdc`: warm/chrome dual theme, лента/комментарии, фильтр `plain_excerpt`.

--- a/docs/GITHUB-PROJECTS-API.md
+++ b/docs/GITHUB-PROJECTS-API.md
@@ -1,0 +1,273 @@
+# GitHub Projects API (Projects v2)
+
+Справка по возможностям и API для синхронизации [`Backlog.md`](Backlog.md) с доской [Flask Blog](https://github.com/users/discipleartem/projects/6).  
+Канон sync: skill `backlog-github-projects-sync` · конфиг [`.github/backlog.json`](../.github/backlog.json).
+
+Официально:
+
+- [Using the API to manage Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects)
+- [GraphQL reference: Projects](https://docs.github.com/en/graphql/reference/projects)
+- [REST: Projects](https://docs.github.com/en/rest/projects/projects) · [REST: Project items](https://docs.github.com/en/rest/projects/items)
+- Classic: [sunset](https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/) (REST classic снят; не использовать)
+
+---
+
+## 1. Возможности Projects v2
+
+| Возможность | Суть |
+|-------------|------|
+| **Items** | Issue, Pull Request или **draft issue** (карточка только на доске) |
+| **Fields** | Встроенные (Title, Assignees, Labels, Milestone, Repository, Linked PRs, Parent issue, Sub-issues progress, даты) + **custom** (single select, text, number, date, iteration) |
+| **Status** | Обычно single select (колонки board): у Flask Blog — `Backlog`, `In progress`, `In review`, `Done` |
+| **Priority** | Custom single select; у Flask Blog — **`P0` / `P1` / `P2`** (не Urgent/High/Medium/Low) |
+| **Size / Estimate / dates** | У Flask Blog есть `Size` (XS…XL), `Estimate`, `Start date`, `Target date` |
+| **Views** | Table / Board / Roadmap; фильтры, группировка, сортировка (через UI; API views ограничен) |
+| **Draft issues** | Быстрые карточки без issue в репо; можно конвертировать в Issue |
+| **Linked issues / sub-issues** | Issue ↔ project item; parent/sub-issues на уровне Issues |
+| **Workflows / automations** | Встроенные правила доски + Actions |
+| **Insights** | Графики в UI |
+
+**Projects (classic)** — deprecated/sunset; для новой автоматизации только **Projects v2** (`ProjectV2`).
+
+---
+
+## 2. Auth и scopes
+
+| Способ | Scope / permission |
+|--------|-------------------|
+| PAT (classic) / `gh` token | Чтение: `read:project`; запись: **`project`** |
+| Fine-grained PAT | Permission **Projects** (Read or Read and write) на owner проекта |
+| GitHub App | Permission **Projects** (+ Contents и др. при `createProjectV2` с `repositoryId`) |
+
+Проверка CLI:
+
+```bash
+gh auth status          # в scopes должен быть project
+gh auth refresh -s project
+```
+
+Endpoint GraphQL: `POST https://api.github.com/graphql`  
+Заголовок: `Authorization: Bearer <TOKEN>`.
+
+---
+
+## 3. GraphQL vs REST vs `gh`
+
+| Канал | Когда |
+|-------|--------|
+| **GraphQL ProjectsV2** | Полный CRUD полей/items; канон для автоматизации |
+| **REST `…/projectsV2`** | Список/get проектов и items (удобно для простых клиентов) |
+| **`gh project …`** | Обёртка над GraphQL; то, чем пользуется sync-скрипт |
+
+CLI (`gh project`): `list`, `view`, `create`, `edit`, `close`, `delete`, `copy`, `field-list` / `field-create` / `field-delete`, `item-list` / `item-add` / `item-create` (draft) / `item-edit` / `item-archive` / `item-delete`, `link` / `unlink`, `mark-template`.
+
+---
+
+## 4. Ключевые GraphQL queries
+
+### Node ID user-проекта
+
+```graphql
+query {
+  user(login: "discipleartem") {
+    projectV2(number: 6) {
+      id
+      title
+    }
+  }
+}
+```
+
+Flask Blog: `id` ≈ `PVT_kwHOAG7bZs4BdzUF`, number `6`.
+
+### Поля (в т.ч. option id для Status / Priority)
+
+```graphql
+query {
+  node(id: "PROJECT_ID") {
+    ... on ProjectV2 {
+      fields(first: 30) {
+        nodes {
+          ... on ProjectV2Field { id name }
+          ... on ProjectV2SingleSelectField {
+            id name
+            options { id name }
+          }
+          ... on ProjectV2IterationField {
+            id name
+            configuration { iterations { id startDate } }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Эквивалент CLI: `gh project field-list 6 --owner discipleartem --format json`.
+
+### Items + значения полей
+
+```graphql
+query {
+  node(id: "PROJECT_ID") {
+    ... on ProjectV2 {
+      items(first: 20) {
+        nodes {
+          id
+          content {
+            ... on Issue { number title }
+            ... on PullRequest { number title }
+            ... on DraftIssue { title body }
+          }
+          fieldValues(first: 15) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldTextValue {
+                text
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## 5. Ключевые GraphQL mutations
+
+> Нельзя в одном вызове и добавить item, и выставить поле: сначала `addProjectV2ItemById`, затем `updateProjectV2ItemFieldValue`.
+
+| Mutation | Назначение |
+|----------|------------|
+| `createProjectV2` | Создать проект |
+| `updateProjectV2` | Настройки (title, public, readme, …) |
+| `deleteProjectV2` | Удалить проект |
+| `addProjectV2ItemById` | Добавить Issue/PR по `contentId` |
+| `addProjectV2DraftIssue` | Draft-карточка |
+| `updateProjectV2ItemFieldValue` | Status, Priority, text/number/date/iteration |
+| `clearProjectV2ItemFieldValue` | Сбросить поле |
+| `deleteProjectV2Item` | Убрать item с доски |
+| `archiveProjectV2Item` | Архив |
+| `convertProjectV2DraftIssueItemToIssue` | Draft → Issue |
+| `createProjectV2Field` / `deleteProjectV2Field` | Custom fields |
+| `linkProjectV2ToRepository` / `unlink…` | Связь с репо |
+
+### Добавить Issue/PR
+
+```graphql
+mutation {
+  addProjectV2ItemById(input: {
+    projectId: "PROJECT_ID"
+    contentId: "ISSUE_OR_PR_NODE_ID"
+  }) {
+    item { id }
+  }
+}
+```
+
+CLI: `gh project item-add 6 --owner discipleartem --url https://github.com/OWNER/REPO/issues/N`.
+
+### Выставить single select (Status / Priority)
+
+```graphql
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PROJECT_ID"
+    itemId: "ITEM_ID"
+    fieldId: "FIELD_ID"
+    value: { singleSelectOptionId: "OPTION_ID" }
+  }) {
+    projectV2Item { id }
+  }
+}
+```
+
+CLI: `gh project item-edit --id ITEM_ID --project-id PROJECT_ID --field-id FIELD_ID --single-select-option-id OPTION_ID`.
+
+### Assignees / Labels / Milestone
+
+Это поля **issue/PR**, не project item. Менять через Mutations Issues (`addAssigneesToAssignable`, `addLabelsToLabelable`, …), не через `updateProjectV2ItemFieldValue`.
+
+---
+
+## 6. REST (Projects v2)
+
+Примеры (user-owned):
+
+| Метод | Path |
+|-------|------|
+| GET | `/users/{username}/projectsV2` |
+| GET | `/users/{username}/projectsV2/{project_number}` |
+| GET | `/orgs/{org}/projectsV2` · `/orgs/{org}/projectsV2/{project_number}` |
+| GET/POST/… | `/users/{username}/projectsV2/{project_number}/items` (и org-аналоги) |
+
+Заголовки: `Accept: application/vnd.github+json`, `Authorization: Bearer …`.
+
+Для полного управления custom fields GraphQL обычно удобнее REST.
+
+---
+
+## 7. Маппинг на backlog flask_blog
+
+Локальный канон — `docs/Backlog.md`. На GitHub: **Issue** (тело) + **Project item** (колонка Status, Priority).
+
+### Status → `**Статус:**`
+
+| Ключ в Backlog | Option на доске Flask Blog |
+|----------------|----------------------------|
+| `open` | Backlog |
+| `in_progress` | In progress |
+| `in_review` | In review |
+| `done` | Done |
+
+Правило статусов агента: [`.cursor/rules/backlog-status.mdc`](../.cursor/rules/backlog-status.mdc).
+
+### Priority → `**Приоритет:**`
+
+Фактические опции доски №6: **`P0`**, **`P1`**, **`P2`**.
+
+| Смысл (из обзоров / планирования) | Option |
+|-----------------------------------|--------|
+| Критично / высокий security | `P0` |
+| Важно, не блокирует прод сразу | `P1` |
+| Низкий / продукт «когда понадобится» | `P2` |
+
+В markdown: `**Приоритет:** P0` (или `**Priority:** P0`). Конфиг: `priorityMap` в `.github/backlog.json` (обычно identity `P0`→`P0`).
+
+### Категории и подзадачи
+
+- **Категория** — метаданные в секции (`**Категория:** Auth / Security`); sync не создаёт отдельный field (на доске можно фильтровать Labels).
+- **Подзадачи** — чеклист в `### Acceptance criteria` / `### Подзадачи` внутри `##` задачи (скрипт синхронизирует одну issue на один `##` заголовок).
+
+---
+
+## 8. Ограничения API
+
+- Add item и update field — **разные** вызовы.
+- Assignees/Labels/Milestone — через Issue API, не Project field mutation.
+- Items без прав доступа → тип `REDACTED`.
+- `gh project item-list --limit` до **500**; больше — пагинация GraphQL/`after`.
+- Classic Projects API — не использовать.
+- Sync skill делает только **push** markdown → GitHub (не pull Status с доски в файл).
+- Нужен scope `project`; без него CLI падает на project-командах.
+
+---
+
+## 9. Практические команды для этого репо
+
+```bash
+gh project view 6 --owner discipleartem --format json
+gh project field-list 6 --owner discipleartem --format json
+gh project item-list 6 --owner discipleartem --format json --limit 50
+
+python ~/.cursor/skills/backlog-github-projects-sync/scripts/sync_backlog.py --dry-run
+python ~/.cursor/skills/backlog-github-projects-sync/scripts/sync_backlog.py
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 | [DEPLOY.md](DEPLOY.md) | PythonAnywhere, `.env` на проде, auto-deploy |
 | [Backlog.md](Backlog.md) | Активные задачи (не история) |
 | [CHANGELOG.md](CHANGELOG.md) | История изменений |
+| [GITHUB-PROJECTS-API.md](GITHUB-PROJECTS-API.md) | GitHub Projects v2: возможности, GraphQL/REST, маппинг backlog |
 
 Ограничения стека (агент): [`.cursor/rules/00-project.mdc`](../.cursor/rules/00-project.mdc).  
 После реализации задачи агент **автоматически** обновляет docs (skill [flask-blog-docs-after-task](../.cursor/skills/flask-blog-docs-after-task/SKILL.md); pointer в `00-project.mdc`; hook `stop`).


### PR DESCRIPTION
## Summary
- Add `docs/GITHUB-PROJECTS-API.md` (Projects v2 capabilities, GraphQL/REST/`gh`, Status/Priority mapping).
- Expand `docs/Backlog.md` with auth/ops hardening tasks (P0–P2) synced to Project board as issues #54–#61.
- Update `backlog.json` / `backlog-status.mdc`: Priority map; remove unused `ready` status.

## Test plan
- [ ] Confirm `docs/README.md` links to `GITHUB-PROJECTS-API.md`
- [ ] Spot-check Backlog entries have `**GitHub:** #54`–`#61` and Priority P0–P2
- [ ] Optional: `python ~/.cursor/skills/backlog-github-projects-sync/scripts/sync_backlog.py --dry-run` parses 8 tasks
- [ ] Project board shows items in Backlog with Priority set


Made with [Cursor](https://cursor.com)