### PR TITLE
fix: GFM markdown table styles and feed excerpts

### DIFF
--- a/app/content_render.py
+++ b/app/content_render.py
@@ -112,6 +112,8 @@ def plain_excerpt(source: str, max_chars: int = 160) -> str:
     text = re.sub(r"!\[([^\]]*)\]\([^)]*\)", r"\1", text)
     text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)
     text = re.sub(r"(?m)^#{1,6}\s+", "", text)
+    # GFM tables: drop row/separator lines so лента не показывает сырые «| … |»
+    text = re.sub(r"(?m)^[ \t]*\|.*\|[ \t]*$", " ", text)
     text = re.sub(r"[>*_~#`]", " ", text)
     text = re.sub(r"\s+", " ", text).strip()
     if not text:

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -205,8 +205,6 @@ body {
   max-width: 100%;
   border-collapse: collapse;
   font-size: 0.95em;
-  overflow-x: auto;
-  display: block;
 }
 
 .post-body thead th,

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -197,6 +197,50 @@ body {
   margin-bottom: 0;
 }
 
+/* GFM tables — Bootstrap reboot strips borders; scope without .table class */
+.post-body table,
+.EasyMDEContainer .editor-preview table,
+.EasyMDEContainer .editor-preview-side table {
+  width: 100%;
+  max-width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95em;
+  overflow-x: auto;
+  display: block;
+}
+
+.post-body thead th,
+.EasyMDEContainer .editor-preview thead th,
+.EasyMDEContainer .editor-preview-side thead th {
+  font-weight: 600;
+  text-align: left;
+  background: color-mix(in srgb, var(--fb-surface) 55%, var(--fb-bg));
+  color: var(--fb-ink);
+}
+
+[data-bs-theme="dark"] .post-body thead th,
+[data-bs-theme="dark"] .EasyMDEContainer .editor-preview thead th,
+[data-bs-theme="dark"] .EasyMDEContainer .editor-preview-side thead th {
+  background: color-mix(in srgb, var(--fb-surface) 80%, #000);
+}
+
+.post-body th,
+.post-body td,
+.EasyMDEContainer .editor-preview th,
+.EasyMDEContainer .editor-preview td,
+.EasyMDEContainer .editor-preview-side th,
+.EasyMDEContainer .editor-preview-side td {
+  border: 1px solid var(--fb-line);
+  padding: 0.55rem 0.75rem;
+  vertical-align: top;
+}
+
+.post-body tbody tr:nth-child(even),
+.EasyMDEContainer .editor-preview tbody tr:nth-child(even),
+.EasyMDEContainer .editor-preview-side tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--fb-muted) 8%, transparent);
+}
+
 /* Code block + copy buttons */
 .code-block {
   position: relative;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,7 +70,7 @@ Identity: `name#NNNN`. Имя `admin` зарезервировано. Seed: `adm
 | `__init__.py` | App factory |
 | `config.py` | Config + `.env` |
 | `db.py` | sqlite3 helpers, миграции |
-| `content_render.py` | Markdown/plain/html → безопасный HTML; `plain_excerpt` для ленты |
+| `content_render.py` | Markdown/plain/html → безопасный HTML (в т.ч. GFM tables); `plain_excerpt` для ленты |
 | `csrf.py` | CSRF token helpers |
 | `auth/` | register/login/logout + helpers |
 | `posts/` | лента, CRUD постов, markdown preview |

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -20,18 +20,20 @@
 
 ### Проблема
 
-GFM-таблицы (`| col |`) парсятся в `<table>` на сервере, но на витрине и в EasyMDE preview выглядят как plain text без borders / header styling (Bootstrap reboot без `.table`).
+GFM-таблицы (`| col |`) парсятся в `<table>` на сервере, но на витрине и в EasyMDE preview выглядят как plain text без borders / header styling (Bootstrap reboot без `.table`). В ленте `plain_excerpt` схлопывал строки таблицы в одну строку с сырыми `|`.
 
 ### Acceptance criteria
 
 - Таблицы в `.post-body` и в preview редактора визуально читаются как таблицы (границы, отступы ячеек, отличие thead).
 - Серверный рендер и preview согласованы (один HTML-пайплайн).
 - Unit-тест: markdown table → `<table>` / `<th>` / `<td>`.
+- Лента: excerpt без сырых `| … |` строк таблицы.
 
 ### Подзадачи
 
 - [x] CSS для `.post-body table` и preview
 - [x] Unit-тест на tables extension
+- [x] `plain_excerpt` отбрасывает GFM table rows
 - [x] Docs + verify
 
 ---

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -13,7 +13,7 @@
 
 ## Content: стили GFM-таблиц в markdown
 
-**Статус:** in_progress
+**Статус:** in_review
 **GitHub:** #63
 **Приоритет:** P1
 **Категория:** Content / Markdown
@@ -30,9 +30,9 @@ GFM-таблицы (`| col |`) парсятся в `<table>` на сервере
 
 ### Подзадачи
 
-- [ ] CSS для `.post-body table` и preview
-- [ ] Unit-тест на tables extension
-- [ ] Docs + verify
+- [x] CSS для `.post-body table` и preview
+- [x] Unit-тест на tables extension
+- [x] Docs + verify
 
 ---
 

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -11,6 +11,31 @@
 
 ---
 
+## Content: стили GFM-таблиц в markdown
+
+**Статус:** in_progress
+**GitHub:** #63
+**Приоритет:** P1
+**Категория:** Content / Markdown
+
+### Проблема
+
+GFM-таблицы (`| col |`) парсятся в `<table>` на сервере, но на витрине и в EasyMDE preview выглядят как plain text без borders / header styling (Bootstrap reboot без `.table`).
+
+### Acceptance criteria
+
+- Таблицы в `.post-body` и в preview редактора визуально читаются как таблицы (границы, отступы ячеек, отличие thead).
+- Серверный рендер и preview согласованы (один HTML-пайплайн).
+- Unit-тест: markdown table → `<table>` / `<th>` / `<td>`.
+
+### Подзадачи
+
+- [ ] CSS для `.post-body table` и preview
+- [ ] Unit-тест на tables extension
+- [ ] Docs + verify
+
+---
+
 ## Auth: CSRF на все mutating POST
 
 **Статус:** open

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 
 - GFM markdown tables: границы/thead/zebra в `.post-body` и EasyMDE preview (`app.css`); extension `tables` уже был в `content_render`.
+- Лента: `plain_excerpt` больше не показывает сырые `| col |` строки GFM-таблиц.
 
 ### Docs
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@
 - UI: лента на главной — карточки статей с иерархией заголовок → excerpt → мета и hover, вместо плоского `list-group`.
 - UI: чтение средней статьи — ритм абзацев/списков, blockquote на surface; в ленте clamp заголовка и excerpt до 3 строк (карточка целиком — ссылка на пост).
 
+### Fixed
+
+- GFM markdown tables: границы/thead/zebra в `.post-body` и EasyMDE preview (`app.css`); extension `tables` уже был в `content_render`.
+
 ### Docs
 
 - `docs/GITHUB-PROJECTS-API.md`: возможности Projects v2, GraphQL/REST/`gh`, маппинг Status/Priority на backlog.
@@ -27,6 +31,8 @@
 - Skill `flask-blog-git-release-sync`: синхронизация `dev` ← `main` после релиза (конфликты CHANGELOG/version — в пользу `main`).
 - DEVELOPMENT §UI / §Контент, ARCHITECTURE и `ui-bootstrap.mdc`: warm/chrome dual theme, лента/комментарии, фильтр `plain_excerpt`.
 - Gate: skill `flask-blog-docs-after-task` обязателен перед PR task → `dev` (порядок docs → verify → push → PR); обновлены `00-project`, `docs-context`, `backlog-status`, `task-cycle`, `git-commit-pr`.
+- DEVELOPMENT §Контент: GFM tables + scoped CSS; Backlog #63.
+
 ## [0.3.0] — 2026-07-21
 
 ### Added

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,10 +23,11 @@
 
 | Слой | Файлы | Поведение |
 |------|--------|-----------|
-| Рендер | `app/content_render.py`, Jinja-фильтры `render_content`, `plain_excerpt` | Markdown / plain / html → nh3 → `Markup`. Лента: `plain_excerpt` — краткий plain-text из `body_source`. Без `| safe` по сырой колонке из БД |
+| Рендер | `app/content_render.py`, Jinja-фильтры `render_content`, `plain_excerpt` | Markdown / plain / html → nh3 → `Markup`. Extensions: `fenced_code`, `tables` (GFM), `nl2br`, `sane_lists`. Лента: `plain_excerpt` — краткий plain-text из `body_source`. Без `| safe` по сырой колонке из БД |
 | Редактор | `app/static/js/markdown-editor.js`, vendor EasyMDE | JS обязателен для форм; чтение витрины без JS |
 | Preview | `POST /markdown/preview` | Тот же `render_to_html`, что на витрине; кнопка «глаз» в тулбаре |
 | Код | `app/static/js/syntax-highlight.js`, стили в `app.css` | Подсветка `pre code.language-*`: python, html, javascript, css, bash (+ aliases); иначе generic. Автоотступы (табы→пробелы, структурный indent); на submit — `formatMarkdownFences` |
+| Таблицы | стили в `app.css` (`.post-body table`, EasyMDE preview) | GFM `| col |` → `<table>`; Bootstrap reboot без `.table` — границы/thead/zebra через scoped CSS на витрине и в preview |
 
 Тулбар «Блок кода»: пресеты Python / HTML / JS / CSS / Bash или свой язык (` ```lang `).
 
@@ -41,11 +42,11 @@
 
 **Bootstrap 5 — канон.** Сетка, навбар, формы, кнопки, alerts, collapse, spacing — через компоненты и utility-классы BS5.
 
-Custom CSS (`app/static/css/app.css`) и JS (`theme.js`, `markdown-editor.js`, `syntax-highlight.js`) — **только исключения**: токены светлой/тёмной темы, бренд-типографика (IBM Plex), градиент hero, переключатель `data-bs-theme`, EasyMDE, подсветка/копирование кода. Не дублировать layout Bootstrap своими правилами и не подключать другие CSS-фреймворки.
+Custom CSS (`app/static/css/app.css`) и JS (`theme.js`, `markdown-editor.js`, `syntax-highlight.js`) — **только исключения**: токены светлой/тёмной темы, бренд-типографика (IBM Plex), градиент hero, переключатель `data-bs-theme`, EasyMDE, подсветка/копирование кода, стили GFM-таблиц в `.post-body` / preview. Не дублировать layout Bootstrap своими правилами и не подключать другие CSS-фреймворки.
 
 **Темы (чтение day/night):** light — тёплый paper/beige фон и мягкий графит; dark — gunmetal / metallic chrome и soft off-white. Токены `--fb-*` в `app.css`; `btn-dark` перекрашен под палитру. Приоритет — контраст и комфорт длинного чтения (`.post-body`), не чистый ч/б.
 
-**Лента / пост / комментарии:** главная — surface-карточки (`.feed-item`), заголовок → excerpt (`plain_excerpt`) → мета; карточка целиком — ссылка на пост. Страница поста — reading column (`.post-body`: абзацы, списки, blockquote). Комментарии — отдельные карточки (`.comment-item`) с `gap`, не плоский список с `border-bottom`.
+**Лента / пост / комментарии:** главная — surface-карточки (`.feed-item`), заголовок → excerpt (`plain_excerpt`) → мета; карточка целиком — ссылка на пост. Страница поста — reading column (`.post-body`: абзацы, списки, blockquote, GFM-таблицы). Комментарии — отдельные карточки (`.comment-item`) с `gap`, не плоский список с `border-bottom`.
 
 ### Mobile / tablet first
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,7 +23,7 @@
 
 | Слой | Файлы | Поведение |
 |------|--------|-----------|
-| Рендер | `app/content_render.py`, Jinja-фильтры `render_content`, `plain_excerpt` | Markdown / plain / html → nh3 → `Markup`. Extensions: `fenced_code`, `tables` (GFM), `nl2br`, `sane_lists`. Лента: `plain_excerpt` — краткий plain-text из `body_source`. Без `| safe` по сырой колонке из БД |
+| Рендер | `app/content_render.py`, Jinja-фильтры `render_content`, `plain_excerpt` | Markdown / plain / html → nh3 → `Markup`. Extensions: `fenced_code`, `tables` (GFM), `nl2br`, `sane_lists`. Лента: `plain_excerpt` — краткий plain-text из `body_source` (строки GFM-таблиц `| … |` отбрасываются). Без `| safe` по сырой колонке из БД |
 | Редактор | `app/static/js/markdown-editor.js`, vendor EasyMDE | JS обязателен для форм; чтение витрины без JS |
 | Preview | `POST /markdown/preview` | Тот же `render_to_html`, что на витрине; кнопка «глаз» в тулбаре |
 | Код | `app/static/js/syntax-highlight.js`, стили в `app.css` | Подсветка `pre code.language-*`: python, html, javascript, css, bash (+ aliases); иначе generic. Автоотступы (табы→пробелы, структурный indent); на submit — `formatMarkdownFences` |

--- a/tests/test_content_render.py
+++ b/tests/test_content_render.py
@@ -70,6 +70,19 @@ class ContentRenderTests(unittest.TestCase):
         self.assertEqual(plain_excerpt(""), "")
         self.assertEqual(plain_excerpt("```\ncode\n```"), "")
 
+    def test_plain_excerpt_strips_gfm_table(self) -> None:
+        src = (
+            "## 1. Архитектура\n\n"
+            "| Слой | Реализация |\n"
+            "| --- | --- |\n"
+            "| Аутентификация | Cookie session |\n"
+            "| CSRF | Свой токен |\n"
+        )
+        excerpt = plain_excerpt(src, max_chars=200)
+        self.assertEqual(excerpt, "1. Архитектура")
+        self.assertNotIn("|", excerpt)
+        self.assertNotIn("---", excerpt)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_content_render.py
+++ b/tests/test_content_render.py
@@ -20,6 +20,16 @@ class ContentRenderTests(unittest.TestCase):
         self.assertIn("print(1)", html)
         self.assertNotIn("```", html)
 
+    def test_markdown_gfm_table(self) -> None:
+        src = "| Col A | Col B |\n| --- | --- |\n| one | two |\n"
+        html = str(render_to_html(src, "markdown"))
+        self.assertIn("<table>", html)
+        self.assertIn("<thead>", html)
+        self.assertIn("<th>Col A</th>", html)
+        self.assertIn("<td>one</td>", html)
+        self.assertIn("<td>two</td>", html)
+        self.assertNotIn("| Col A |", html)
+
     def test_plaintext_escapes_and_breaks(self) -> None:
         html = str(render_to_html("a <b>x</b>\nline", "plaintext"))
         self.assertIn("&lt;b&gt;", html)


### PR DESCRIPTION
## Summary
- Style GFM `<table>` in `.post-body` and EasyMDE preview (Bootstrap reboot left tables borderless).
- Strip GFM table rows from `plain_excerpt` so the home feed no longer shows raw `| col |` pipes.
- Backlog #63 (`in_review`) + unit tests for table render and excerpt stripping.

## Test plan
- [ ] Open a post with a GFM table — cells have borders/padding; thead distinct
- [ ] EasyMDE preview of the same markdown matches the public page
- [ ] Home feed card for a table-heavy post shows prose excerpt without `| … |`
- [ ] `python -m unittest tests.test_content_render -v`


Made with [Cursor](https://cursor.com)