### PR TITLE
docs: mark GFM tables backlog #63 done

### DIFF
--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -11,33 +11,6 @@
 
 ---
 
-## Content: стили GFM-таблиц в markdown
-
-**Статус:** in_review
-**GitHub:** #63
-**Приоритет:** P1
-**Категория:** Content / Markdown
-
-### Проблема
-
-GFM-таблицы (`| col |`) парсятся в `<table>` на сервере, но на витрине и в EasyMDE preview выглядят как plain text без borders / header styling (Bootstrap reboot без `.table`). В ленте `plain_excerpt` схлопывал строки таблицы в одну строку с сырыми `|`.
-
-### Acceptance criteria
-
-- Таблицы в `.post-body` и в preview редактора визуально читаются как таблицы (границы, отступы ячеек, отличие thead).
-- Серверный рендер и preview согласованы (один HTML-пайплайн).
-- Unit-тест: markdown table → `<table>` / `<th>` / `<td>`.
-- Лента: excerpt без сырых `| … |` строк таблицы.
-
-### Подзадачи
-
-- [x] CSS для `.post-body table` и preview
-- [x] Unit-тест на tables extension
-- [x] `plain_excerpt` отбрасывает GFM table rows
-- [x] Docs + verify
-
----
-
 ## Auth: CSRF на все mutating POST
 
 **Статус:** open

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Skill `flask-blog-git-release-sync`: синхронизация `dev` ← `main` после релиза (конфликты CHANGELOG/version — в пользу `main`).
 - DEVELOPMENT §UI / §Контент, ARCHITECTURE и `ui-bootstrap.mdc`: warm/chrome dual theme, лента/комментарии, фильтр `plain_excerpt`.
 - Gate: skill `flask-blog-docs-after-task` обязателен перед PR task → `dev` (порядок docs → verify → push → PR); обновлены `00-project`, `docs-context`, `backlog-status`, `task-cycle`, `git-commit-pr`.
-- DEVELOPMENT §Контент: GFM tables + scoped CSS; Backlog #63.
+- DEVELOPMENT §Контент: GFM tables + scoped CSS; Backlog #63 выполнен и удалён из `Backlog.md` после merge в `dev`.
 
 ## [0.3.0] — 2026-07-21
 


### PR DESCRIPTION
## Summary
- Close out Backlog #63 after merge of #64: status done → sync (issue closed) → remove section from `Backlog.md`.
- Note completion in CHANGELOG Docs.

## Test plan
- [ ] `docs/Backlog.md` has no #63 section
- [ ] Issue #63 is closed


Made with [Cursor](https://cursor.com)