### PR TITLE
docs: mark OG social preview backlog #67 done

### DIFF
--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -11,34 +11,6 @@
 
 ---
 
-## SEO: Open Graph / Twitter Card превью ссылок на статьи
-
-**Статус:** in_review
-**GitHub:** #67
-**Приоритет:** P2
-**Категория:** UI / SEO
-
-### Проблема
-
-При вставке URL статьи в Telegram, Discord, Slack, VK и т.п. не показывается карточка сайта: в `<head>` нет `og:*` / `twitter:*` (только `<title>`). Краулеры не из чего собрать превью.
-
-### Acceptance criteria
-
-- Страница `/posts/<id>` отдаёт `og:title`, `og:description`, `og:url`, `og:type`, `og:image` (абсолютные URL) и базовые Twitter Card теги.
-- Description — plain-text excerpt из `body_source` (reuse `plain_excerpt`).
-- `og:image`: первое абсолютное изображение из Markdown тела, иначе дефолтная картинка сайта в `static/`.
-- Unit-тесты: meta-теги присутствуют в HTML ответа detail.
-- Кратко задокументировано в DEVELOPMENT / ARCHITECTURE.
-
-### Подзадачи
-
-- [x] Meta-теги в `posts/detail.html` (+ при необходимости site-level на главной)
-- [x] Хелпер первого image URL из Markdown; дефолтный `og-default` asset
-- [x] Unit-тесты
-- [x] Docs
-
----
-
 ## Auth: CSRF на все mutating POST
 
 **Статус:** open

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@
 - DEVELOPMENT §UI / §Контент, ARCHITECTURE и `ui-bootstrap.mdc`: warm/chrome dual theme, лента/комментарии, фильтр `plain_excerpt`.
 - Gate: skill `flask-blog-docs-after-task` обязателен перед PR task → `dev` (порядок docs → verify → push → PR); обновлены `00-project`, `docs-context`, `backlog-status`, `task-cycle`, `git-commit-pr`.
 - DEVELOPMENT §Контент: GFM tables + scoped CSS; Backlog #63 выполнен и удалён из `Backlog.md` после merge в `dev`.
+- DEVELOPMENT §Контент: Open Graph / Twitter Card; Backlog #67 выполнен и удалён из `Backlog.md` после merge в `dev`.
 
 ## [0.3.0] — 2026-07-21
 


### PR DESCRIPTION
## Summary
- Backlog #67 → Done (synced to Project), section removed from `Backlog.md`
- CHANGELOG note after merge of #68

## Test plan
- [ ] Confirm #67 is Done on GitHub Project
- [ ] `Backlog.md` no longer lists the OG preview task


Made with [Cursor](https://cursor.com)