### PR TITLE
docs: auto-merge backlog cleanup after task merge

### DIFF
--- a/.cursor/rules/backlog-status.mdc
+++ b/.cursor/rules/backlog-status.mdc
@@ -25,10 +25,11 @@ alwaysApply: false
 |---------|--------|
 | Старт реализации задачи из backlog (сразу после git-старта / взятия в работу) | `in_progress` |
 | Создание PR task-ветки → `dev` (integration) | `in_review` (**до** `gh pr create`, в skill `flask-blog-docs-after-task`) |
-| Merge PR в `dev` (или явный запрос пользователя) | `done` → sync → запись в `CHANGELOG.md` → **удалить** секцию задачи из `Backlog.md` |
+| Merge PR в `dev` (или явный запрос пользователя `merged` / MERGED) | `done` → sync → CHANGELOG → **удалить** секцию из `Backlog.md` — skill [`flask-blog-git-merged-archive`](../skills/flask-blog-git-merged-archive/SKILL.md) |
 
 - Менять статус **в том же коммите** (или сразу следующим), что и событие; затем `python ~/.cursor/skills/backlog-github-projects-sync/scripts/sync_backlog.py`.
 - После `done` и sync: итог — в [`docs/CHANGELOG.md`](../../docs/CHANGELOG.md); секцию из `Backlog.md` убрать.
+- **Post-merge очистка — в том же turn, что и `merged`:** docs-PR → **сразу** `gh pr merge --squash` → архив docs-ветки → `dev` с актуальным `Backlog.md`. **Не** оставлять открытый `docs/*-backlog-done` «на потом» (иначе на `dev` остаётся секция `in_review` и растут конфликты при параллельных правках backlog).
 - **Не** ставить `done` только потому, что реализация на ветке закончена — до подготовки PR остаётся `in_progress`; `in_review` — в docs-after-task **перед** `gh pr create`.
 - Задачи без записи в `Backlog.md` — правило не применять.
 - Scoping — [`AGENTS.md`](../../AGENTS.md) / `docs-context.mdc`.

--- a/.cursor/rules/git-merged-branches.mdc
+++ b/.cursor/rules/git-merged-branches.mdc
@@ -18,4 +18,4 @@ alwaysApply: false
 
 Имена: `feat/foo` → `merged/foo` (префикс снимается).
 
-**Алгоритм (bash + follow-up docs PR):** skill [`flask-blog-git-merged-archive`](../skills/flask-blog-git-merged-archive/SKILL.md) — Read и выполнить в том же turn после MERGED.
+**Алгоритм (bash + follow-up backlog):** skill [`flask-blog-git-merged-archive`](../skills/flask-blog-git-merged-archive/SKILL.md) — Read и выполнить в том же turn после MERGED. Очистка `Backlog.md` (`done` → sync → удалить секцию) — **сразу merge** docs-PR в том же turn; не оставлять открытый `docs/*-backlog-done`.

--- a/.cursor/skills/flask-blog-docs-after-task/SKILL.md
+++ b/.cursor/skills/flask-blog-docs-after-task/SKILL.md
@@ -77,5 +77,5 @@ Post-merge rename — skill [`flask-blog-git-merged-archive`](../flask-blog-git-
 
 ## После merge в `dev` (не этот skill целиком)
 
-1. Backlog: `done` → sync → CHANGELOG (если ещё нет) → **удалить** секцию из `Backlog.md` — skill backlog-sync.
-2. Ветки: `feat|docs/…` → `merged/…`, **checkout `dev`** — skill `flask-blog-git-merged-archive`.
+1. Backlog: `done` → sync → CHANGELOG (если ещё нет) → **удалить** секцию из `Backlog.md` — skill backlog-sync + skill [`flask-blog-git-merged-archive`](../flask-blog-git-merged-archive/SKILL.md) (docs-PR **сразу** squash-merge в том же turn; не ждать пользователя).
+2. Ветки: `feat|docs/…` → `merged/…`, **checkout `dev`** — тот же skill `flask-blog-git-merged-archive`.

--- a/.cursor/skills/flask-blog-git-merged-archive/SKILL.md
+++ b/.cursor/skills/flask-blog-git-merged-archive/SKILL.md
@@ -41,11 +41,31 @@ git status -sb
 
 **Release → `main`:** сначала sync `dev` ← `main` — skill [`flask-blog-git-release-sync`](../flask-blog-git-release-sync/SKILL.md), затем архив `release/…` этим skill.
 
-**Backlog `done` / docs** — если нужен отдельный PR (`docs/…-backlog-done`):
+### Backlog `done` / очистка `Backlog.md` (тот же turn)
 
-1. Ветка **от актуального `dev`**, коммит, push, `gh pr create --base dev`
-2. Сразу после push/PR: `git checkout dev`
-3. После merge docs-PR — снова полный алгоритм выше
+Если смерженный PR закрывал задачу из [`docs/Backlog.md`](../../../docs/Backlog.md) — **не оставлять** открытый docs-PR и **не** заканчивать turn, пока секция задачи ещё есть на `origin/dev`.
+
+Иначе: пользователь видит «живую» задачу после merge фичи; параллельные правки `Backlog.md` → merge-конфликты.
+
+Алгоритм (после шага архива task-ветки, на актуальном `dev`):
+
+```bash
+git checkout -b docs/<short>-backlog-done   # от origin/dev
+# 1) **Статус:** done → sync_backlog.py
+# 2) CHANGELOG [Unreleased]/Docs: задача #N выполнена…
+# 3) Удалить ##-секцию задачи из Backlog.md
+git add docs/Backlog.md docs/CHANGELOG.md
+git commit -m "docs: mark backlog #N done after merge"
+git push -u origin HEAD
+gh pr create --base dev --title "docs: mark backlog #N done" --body "…"
+gh pr merge --squash          # СРАЗУ в этом turn — не ждать пользователя
+git fetch origin
+# архив docs-ветки тем же алгоритмом → merged/<short>-backlog-done
+git checkout dev && git pull --ff-only origin dev
+# проверка: секции задачи нет в docs/Backlog.md
+```
+
+Кратко: **create → merge → archive docs → на `dev`**. Открытый `docs/*-backlog-done` без merge — ошибка процесса.
 
 ## Запрещено
 
@@ -53,3 +73,4 @@ git status -sb
 - PR / работа с head `merged/…`
 - Force-push `main` / `dev`
 - Завершать turn на task / `docs/*` / `merged/*` вместо `dev` (или `main`)
+- Завершать MERGED-turn с открытым PR `docs/*-backlog-done` или с секцией закрытой задачи всё ещё в `origin/dev:docs/Backlog.md`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Gate: skill `flask-blog-docs-after-task` обязателен перед PR task → `dev` (порядок docs → verify → push → PR); обновлены `00-project`, `docs-context`, `backlog-status`, `task-cycle`, `git-commit-pr`.
 - DEVELOPMENT §Контент: GFM tables + scoped CSS; Backlog #63 выполнен и удалён из `Backlog.md` после merge в `dev`.
 - DEVELOPMENT §Контент: Open Graph / Twitter Card; Backlog #67 выполнен и удалён из `Backlog.md` после merge в `dev`.
+- Post-merge: skill `flask-blog-git-merged-archive` — docs/backlog cleanup PR сразу squash-merge в том же turn (не оставлять открытый `docs/*-backlog-done`); обновлены `backlog-status.mdc`, `git-merged-branches.mdc`.
 
 ## [0.3.0] — 2026-07-21
 

--- a/docs/GITHUB-PROJECTS-API.md
+++ b/docs/GITHUB-PROJECTS-API.md
@@ -230,6 +230,8 @@ CLI: `gh project item-edit --id ITEM_ID --project-id PROJECT_ID --field-id FIELD
 
 Правило статусов агента: [`.cursor/rules/backlog-status.mdc`](../.cursor/rules/backlog-status.mdc).
 
+После merge task-PR в `dev`: агент в том же turn ставит `done`, sync, удаляет секцию из `Backlog.md` и **сразу** squash-merge docs-PR (skill [`flask-blog-git-merged-archive`](../.cursor/skills/flask-blog-git-merged-archive/SKILL.md)) — иначе на `dev` остаётся «закрытая» секция и растут конфликты при параллельных правках backlog.
+
 ### Priority → `**Приоритет:**`
 
 Фактические опции доски №6: **`P0`**, **`P1`**, **`P2`**.


### PR DESCRIPTION
## Summary
- After \`merged\`, backlog cleanup (\`done\` → sync → remove section) must **squash-merge in the same turn** — no open \`docs/*-backlog-done\` left for the user
- Avoids stale \`in_review\` sections on \`dev\` and merge conflicts on \`Backlog.md\`
- Updated: \`flask-blog-git-merged-archive\`, \`backlog-status\`, \`git-merged-branches\`, \`flask-blog-docs-after-task\`, GITHUB-PROJECTS-API

## Test plan
- [ ] Next feature merge + \`merged\`: agent archives task, creates docs cleanup PR, merges it immediately, ends on \`dev\` without the closed task in \`Backlog.md\`


Made with [Cursor](https://cursor.com)