### PR TITLE
docs: canonize GitHub Releases API and release skills

### DIFF
--- a/.cursor/skills/flask-blog-docs-after-task/SKILL.md
+++ b/.cursor/skills/flask-blog-docs-after-task/SKILL.md
@@ -61,6 +61,7 @@ Post-merge rename — skill [`flask-blog-git-merged-archive`](../flask-blog-git-
 | Схема БД | `schema.sql` + `migrations/` + ARCHITECTURE §Данные |
 | Howto: UI, Markdown/код-блоки, IronBee, локальный запуск | [`docs/DEVELOPMENT.md`](../../../docs/DEVELOPMENT.md) |
 | Деплой / PA / CI hook | [`docs/DEPLOY.md`](../../../docs/DEPLOY.md) |
+| Релиз / GitHub Release / sync skills | [`docs/RELEASE.md`](../../../docs/RELEASE.md), [`docs/github-releases-api.md`](../../../docs/github-releases-api.md) |
 | Заметные фичи / фиксы | [`docs/CHANGELOG.md`](../../../docs/CHANGELOG.md) |
 | Новый тип задачи для scoping | [`AGENTS.md`](../../../AGENTS.md) (+ при необходимости [`docs/README.md`](../../../docs/README.md)) |
 | Запреты стека / gate docs→PR | [`.cursor/rules/00-project.mdc`](../../rules/00-project.mdc) (+ тематический `*.mdc`) |

--- a/.cursor/skills/flask-blog-git-merged-archive/SKILL.md
+++ b/.cursor/skills/flask-blog-git-merged-archive/SKILL.md
@@ -39,7 +39,7 @@ git status -sb
 
 ## Follow-up
 
-**Release → `main`:** сначала sync `dev` ← `main` — skill [`flask-blog-git-release-sync`](../flask-blog-git-release-sync/SKILL.md), затем архив `release/…` этим skill.
+**Release → `main`:** полный поток — skill [`flask-blog-git-release`](../flask-blog-git-release/SKILL.md); после merge — sync [`flask-blog-git-release-sync`](../flask-blog-git-release-sync/SKILL.md), затем архив `release/…` этим skill.
 
 ### Backlog `done` / очистка `Backlog.md` (тот же turn)
 

--- a/.cursor/skills/flask-blog-git-release-sync/SKILL.md
+++ b/.cursor/skills/flask-blog-git-release-sync/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: flask-blog-git-release-sync
 description: >-
-  After a release PR is merged into main (and optional GitHub Release): merge
-  origin/main into dev, resolve release-file conflicts preferring main, push
-  origin/dev. Use when user says sync after release, sync dev with main after
-  vX.Y.Z, or post-release when git log dev..origin/main is not empty.
+  After a release PR is merged into main (and GitHub Release with all fields):
+  merge origin/main into dev, resolve release-file conflicts preferring main,
+  push origin/dev. Use when user says sync after release, sync dev with main
+  after vX.Y.Z, or post-release when git log dev..origin/main is not empty.
 ---
 
 # flask_blog — sync `dev` ← `main` после релиза
 
+Полный релиз (подготовка → PR → **GitHub Release со всеми полями** → этот sync): skill [`flask-blog-git-release`](../flask-blog-git-release/SKILL.md).  
 Общий sync (не только релиз): skill [`git-dev-main-sync`](~/.cursor/skills/git-dev-main-sync/SKILL.md).  
-Архив release-ветки: skill [`flask-blog-git-merged-archive`](../flask-blog-git-merged-archive/SKILL.md).
+Архив release-ветки: skill [`flask-blog-git-merged-archive`](../flask-blog-git-merged-archive/SKILL.md).  
+API / поля Release: [`docs/github-releases-api.md`](../../../docs/github-releases-api.md) · процесс: [`docs/RELEASE.md`](../../../docs/RELEASE.md).
 
-**Когда:** сразу после squash merge release-PR в `main` (и при необходимости `gh release create`).  
+**Когда:** сразу после squash merge release-PR в `main` и создания GitHub Release (`gh release create` / API).  
 **Цель:** `git log dev..origin/main --oneline` пуст; закончить на `dev`.
+
+Если Release ещё не создан — сначала skill **`flask-blog-git-release`** §3 (все поля: tag, title, body, target=`main`, draft/prerelease явно, `--latest`), затем этот sync.
 
 ## Алгоритм
 
@@ -53,9 +57,10 @@ git commit --no-edit   # или -m "chore: sync dev with main after ${VERSION}"
 git push origin dev
 git log dev..origin/main --oneline   # must be empty
 git status -sb                       # на dev
+gh release view "${VERSION}"         # title/body непустые (если Release уже создан)
 ```
 
-После успешного sync — при необходимости архив `release/vX.Y.Z` → `merged/vX.Y.Z` (skill `flask-blog-git-merged-archive`).
+После успешного sync — архив `release/vX.Y.Z` → `merged/vX.Y.Z` (skill `flask-blog-git-merged-archive`).
 
 ## Нельзя
 
@@ -63,3 +68,4 @@ git status -sb                       # на dev
 - Оставлять `[Unreleased]` с уже выпущенными пунктами (брать CHANGELOG с `main`)
 - Завершать turn на `release/*` / `merged/*` вместо `dev`
 - Bare `git pull origin main` без явной стратегии merge
+- Считать релиз завершённым, если GitHub Release создан без title/body/target (исправить через `gh release edit` или skill `flask-blog-git-release`)

--- a/.cursor/skills/flask-blog-git-release/SKILL.md
+++ b/.cursor/skills/flask-blog-git-release/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: flask-blog-git-release
+description: >-
+  Cut a flask_blog release to main: prepare CHANGELOG/version, PR squash into
+  main, create GitHub Release with ALL fields filled (tag, title, body, target,
+  draft/prerelease, latest), then sync dev and archive release/*. Use when user
+  says релиз, релиз в main, release, or cut release.
+---
+
+# flask_blog — релиз в `main`
+
+Канон: [`docs/RELEASE.md`](../../../docs/RELEASE.md) · API: [`docs/github-releases-api.md`](../../../docs/github-releases-api.md).
+
+После merge: sync — [`flask-blog-git-release-sync`](../flask-blog-git-release-sync/SKILL.md); архив — [`flask-blog-git-merged-archive`](../flask-blog-git-merged-archive/SKILL.md).  
+PR/commit процедуры: [`git-commit-pr`](~/.cursor/skills/git-commit-pr/SKILL.md).
+
+**Триггеры:** «релиз», «релиз в main», «release», «cut release».
+
+## Жёсткое правило: все поля Release
+
+При `gh release create` / `POST …/releases` **обязательно** задать (не оставлять пустыми и не полагаться на молчаливые defaults для смысла релиза):
+
+| Поле | Обязательно | Значение по умолчанию в проекте |
+|------|-------------|----------------------------------|
+| `tag_name` / tag | да | `vX.Y.Z` |
+| `name` / `--title` | да | `Flask Blog X.Y.Z` |
+| `body` / `-F` notes | да | секция `[X.Y.Z]` из `docs/CHANGELOG.md` |
+| `target_commitish` / `--target` | да | `main` |
+| `draft` | явно | published → **не** передавать `--draft` |
+| `prerelease` | явно | full → **не** передавать `--prerelease` (иначе только если пользователь просил pre) |
+| `make_latest` / `--latest` | да | `--latest` для обычного релиза |
+| `generate_release_notes` | решить явно | предпочтение: body из CHANGELOG; `--generate-notes` только как дополнение |
+
+**Запрещено:** `gh release create vX.Y.Z` без `--title`, без notes, без `--target`.
+
+---
+
+## Алгоритм
+
+### 0. Версия и предпосылки
+
+```bash
+git fetch origin
+# origin/dev актуален; git log origin/dev..origin/main — пуст (иначе сначала sync)
+VERSION=0.4.0          # SemVer без v — согласовать с пользователем / Unreleased
+TAG="v${VERSION}"
+TITLE="Flask Blog ${VERSION}"
+```
+
+### 1. Ветка подготовки
+
+```bash
+git checkout dev && git pull --ff-only origin dev
+git checkout -b "release/${TAG}"
+```
+
+- `pyproject.toml`: `version = "${VERSION}"`
+- `docs/CHANGELOG.md`: перенести `[Unreleased]` → `## [${VERSION}] — YYYY-MM-DD`; оставить пустой `[Unreleased]`
+- Commit: `chore: release ${TAG}`
+- Push: `git push -u origin HEAD`
+
+### 2. PR → `main` (только по запросу на PR)
+
+```bash
+gh pr create --base main --head "release/${TAG}" --title "Release ${TAG}" --body "…"
+# после approve / по запросу:
+gh pr merge --squash --delete-branch=false
+git fetch origin
+```
+
+Дождаться, что `origin/main` содержит squash (CI/deploy могут идти параллельно — см. DEPLOY).
+
+### 3. GitHub Release — полный набор полей
+
+Извлечь body из CHANGELOG (секция версии) во временный файл, затем:
+
+```bash
+# /tmp/release-body.md — markdown секции [X.Y.Z] (без пустого Unreleased)
+
+gh release create "${TAG}" \
+  --title "${TITLE}" \
+  --notes-file /tmp/release-body.md \
+  --target main \
+  --latest
+```
+
+Эквивалент REST (`gh api`):
+
+```bash
+gh api repos/{owner}/{repo}/releases \
+  -f tag_name="${TAG}" \
+  -f target_commitish=main \
+  -f name="${TITLE}" \
+  -f body="$(cat /tmp/release-body.md)" \
+  -F draft=false \
+  -F prerelease=false \
+  -F generate_release_notes=false \
+  -f make_latest=true
+```
+
+Проверка:
+
+```bash
+gh release view "${TAG}"
+# title и body непустые; tag = TAG
+```
+
+Опционально (дополнение к CHANGELOG, не замена):
+
+```bash
+gh release create "${TAG}" \
+  --title "${TITLE}" \
+  --notes-file /tmp/release-body.md \
+  --generate-notes \
+  --target main \
+  --latest
+```
+
+### 4. Sync `dev` ← `main`
+
+Выполнить skill **`flask-blog-git-release-sync`** с `VERSION=${TAG}`.
+
+### 5. Архив ветки
+
+Skill **`flask-blog-git-merged-archive`**: `release/vX.Y.Z` → `merged/vX.Y.Z`, закончить на `dev`.
+
+---
+
+## Нельзя
+
+- Release без title/body/target
+- `target` ≠ `main` без явного указания пользователя
+- Force-push `main` / `dev`
+- Завершать turn без sync после merge в `main`
+- Создавать PR в `main` без запроса пользователя на PR (подготовка ветки/CHANGELOG — можно)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 | Markdown-редактор / подсветка | DEVELOPMENT §Контент | `content_render.py`, `static/js/markdown-editor.js`, `syntax-highlight.js` | DEPLOY, auth |
 | CSRF / config / factory | ARCHITECTURE §Поток | `app/__init__.py`, `app/csrf.py`, `app/config.py` | DEPLOY |
 | Деплой / PA / hook | DEPLOY | `app/deploy/`, `.github/workflows/` | DEVELOPMENT UI, IronBee |
+| Релиз / GitHub Release | RELEASE, github-releases-api | skills `flask-blog-git-release*`, `docs/CHANGELOG.md` | UI, IronBee, schema |
 | Тесты | `testing.mdc` | `tests/` (+ модуль под тестом) | DEPLOY, static vendor |
 | Backlog / статусы задач | `backlog-status.mdc`, Backlog.md | — | код приложения |
 | Docs / карта проекта | этот файл, `docs/README.md` | `docs/`, `AGENTS.md`, `.cursor/rules/docs-context.mdc` | широкий `app/` |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Docs
 
+- `docs/RELEASE.md` + `docs/github-releases-api.md`: канон релиза `dev`→`main` и справка GitHub Releases API; skill `flask-blog-git-release` (все поля Release обязательны).
 - `docs/GITHUB-PROJECTS-API.md`: возможности Projects v2, GraphQL/REST/`gh`, маппинг Status/Priority на backlog.
 - Backlog: auth/security задачи из обзора (CSRF, `next`, rate limit, session, пароли, prod defaults) с Priority P0–P2; sync → issues #54–#61 на Project «Flask Blog».
 - `backlog.json` / `backlog-status.mdc`: поле Priority; статус `ready` убран из `statusMap`.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -219,6 +219,8 @@ Web → Static files:
 
 ## Auto-deploy через GitHub
 
+Процесс релиза (PR → squash → GitHub Release → sync `dev`): [`RELEASE.md`](RELEASE.md).
+
 Цель: релиз `dev` **→** `main` на GitHub сам выкатывает код на PythonAnywhere без ручного `git pull` и кнопки Reload.
 
 Workflow: [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Scoping: слои, маршруты, схема, права, карта `app/` |
 | [DEVELOPMENT.md](DEVELOPMENT.md) | Локальный запуск, UI, контент/Markdown, IronBee, проверки |
 | [DEPLOY.md](DEPLOY.md) | PythonAnywhere, `.env` на проде, auto-deploy |
+| [RELEASE.md](RELEASE.md) | Релиз `dev`→`main`: PR, squash, GitHub Release, sync |
+| [github-releases-api.md](github-releases-api.md) | GitHub REST API Releases: endpoints, поля, `gh` |
 | [Backlog.md](Backlog.md) | Активные задачи (не история) |
 | [CHANGELOG.md](CHANGELOG.md) | История изменений |
 | [GITHUB-PROJECTS-API.md](GITHUB-PROJECTS-API.md) | GitHub Projects v2: возможности, GraphQL/REST, маппинг backlog |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,65 @@
+# Release (dev → main)
+
+Канон релиза flask_blog: PR `dev`/`release/*` **→** `main` (squash), GitHub Release с полным набором полей, sync `dev` ← `main`, архив ветки.
+
+Справка API: [`github-releases-api.md`](github-releases-api.md).  
+Skills: [`flask-blog-git-release`](../.cursor/skills/flask-blog-git-release/SKILL.md) · [`flask-blog-git-release-sync`](../.cursor/skills/flask-blog-git-release-sync/SKILL.md) · [`flask-blog-git-merged-archive`](../.cursor/skills/flask-blog-git-merged-archive/SKILL.md).
+
+Триггеры агента: «релиз», «релиз в main», «release», «cut release» — Read и выполнить **`flask-blog-git-release`**.
+
+После squash в `main` срабатывает auto-deploy ([`DEPLOY.md`](DEPLOY.md) §Auto-deploy).
+
+---
+
+## Поток
+
+```text
+  1. Подготовка на ветке release/vX.Y.Z (от актуального origin/dev)
+       · bump version в pyproject.toml
+       · docs/CHANGELOG.md: [Unreleased] → [X.Y.Z] — YYYY-MM-DD; пустой [Unreleased]
+  2. PR release/vX.Y.Z → main  (только по запросу пользователя на PR)
+  3. Squash merge в main
+  4. GitHub Release (все поля заполнены — см. ниже)
+  5. Sync: skill flask-blog-git-release-sync  (dev ← origin/main)
+  6. Архив: release/vX.Y.Z → merged/vX.Y.Z  (flask-blog-git-merged-archive)
+```
+
+Шаги 8–10 global [`task-cycle.mdc`](~/.cursor/rules/task-cycle.mdc): PR integration→main → squash → sync. В этом репо sync после релиза — **project** skill `flask-blog-git-release-sync` (конфликты CHANGELOG/version → **main**).
+
+---
+
+## Обязательные поля GitHub Release
+
+При «релиз» / «релиз в main» **запрещено** создавать Release с пустыми `name`/`body` или неявным target. Заполнить:
+
+| Поле (API) | CLI `gh release create` | Значение в проекте |
+|------------|-------------------------|--------------------|
+| `tag_name` | позиционный `<tag>` | `vX.Y.Z` (= версия из `pyproject.toml` с префиксом `v`) |
+| `name` | `--title` | `Flask Blog X.Y.Z` |
+| `body` | `--notes-file` / `-F` | секция `[X.Y.Z]` из `docs/CHANGELOG.md` |
+| `target_commitish` | `--target` | `main` |
+| `draft` | флаг `--draft` или его отсутствие | явно published: **без** `--draft` |
+| `prerelease` | `--prerelease` или нет | явно full: **без** `--prerelease` (иначе только по запросу) |
+| `make_latest` | `--latest` | `--latest` для обычного релиза |
+| `generate_release_notes` | `--generate-notes` | опционально; не вместо CHANGELOG |
+
+Проверка: `gh release view "vX.Y.Z"` — непустые title и body, target/tag корректны.
+
+---
+
+## Версии и CHANGELOG
+
+- SemVer в `pyproject.toml` `version = "X.Y.Z"`.
+- Тег Release: `vX.Y.Z`.
+- Перед PR в `main`: перенести пункты из `[Unreleased]` в `## [X.Y.Z] — YYYY-MM-DD`, оставить пустой `[Unreleased]`.
+- Body Release = markdown этой секции (заголовок версии можно не дублировать в notes, если title уже задан).
+
+---
+
+## Чего не делать
+
+- Push напрямую в `main` в обход PR (кроме явного запроса).
+- Force-push `main` / `dev`.
+- Release с target ≠ `main` без явного указания пользователя.
+- Завершать релиз без sync `dev` ← `main`.
+- Оставлять remote `release/*` без архива `merged/*` (см. [`git-merged-branches.mdc`](../.cursor/rules/git-merged-branches.mdc)).

--- a/docs/github-releases-api.md
+++ b/docs/github-releases-api.md
@@ -1,0 +1,141 @@
+# GitHub Releases API (REST)
+
+Краткая справка для агентов flask_blog. Канон процесса релиза: [`RELEASE.md`](RELEASE.md).  
+Создание Release в репо: skill [`flask-blog-git-release`](../.cursor/skills/flask-blog-git-release/SKILL.md).
+
+Официально:
+
+- [REST: Releases](https://docs.github.com/en/rest/releases/releases)
+- [REST: Release assets](https://docs.github.com/en/rest/releases/assets)
+- [CLI: `gh release create`](https://cli.github.com/manual/gh_release_create)
+
+Заголовки (типично): `Authorization: Bearer <TOKEN>`, `Accept: application/vnd.github+json`, `X-GitHub-Api-Version` (актуальная версия — в docs GitHub).
+
+---
+
+## 1. Endpoints
+
+| Действие | Метод | Путь |
+|----------|-------|------|
+| List releases | `GET` | `/repos/{owner}/{repo}/releases` |
+| Create release | `POST` | `/repos/{owner}/{repo}/releases` |
+| Generate notes (без сохранения) | `POST` | `/repos/{owner}/{repo}/releases/generate-notes` |
+| Latest published | `GET` | `/repos/{owner}/{repo}/releases/latest` |
+| By tag | `GET` | `/repos/{owner}/{repo}/releases/tags/{tag}` |
+| By id | `GET` | `/repos/{owner}/{repo}/releases/{release_id}` |
+| Update | `PATCH` | `/repos/{owner}/{repo}/releases/{release_id}` |
+| Delete | `DELETE` | `/repos/{owner}/{repo}/releases/{release_id}` |
+| List assets | `GET` | `/repos/{owner}/{repo}/releases/{release_id}/assets` |
+| Upload asset | `POST` | `https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets?name=` |
+| Get / update / delete asset | `GET`/`PATCH`/`DELETE` | `/repos/{owner}/{repo}/releases/assets/{asset_id}` |
+
+List **не** включает обычные git-теги без Release. Drafts в list видят только пользователи с push.
+
+---
+
+## 2. Create release — поля body
+
+`POST /repos/{owner}/{repo}/releases`
+
+| Поле | API | В flask_blog при «релиз» |
+|------|-----|--------------------------|
+| `tag_name` | **обязателен** | версия с `v`, напр. `v0.4.0` |
+| `target_commitish` | опционален (default = default branch) | **всегда** `main` |
+| `name` | опционален | **всегда** человекочитаемый title (напр. `Flask Blog 0.4.0`) |
+| `body` | опционален | **всегда** из секции `docs/CHANGELOG.md` для версии |
+| `draft` | bool, default `false` | **явно** `false` (published), иначе `true` только по запросу |
+| `prerelease` | bool, default `false` | **явно** `false`, иначе `true` только по запросу |
+| `generate_release_notes` | bool, default `false` | опционально `true`: auto-notes; если задан `body`, он **prepend** к auto |
+| `make_latest` | `"true"` \| `"false"` \| `"legacy"`, default `"true"` | `"true"` для обычного релиза; drafts/prereleases не могут быть latest |
+| `discussion_category_name` | string | не использовать, пока в репо нет Discussions category |
+
+**Правило проекта:** при командах «релиз» / «релиз в main» не полагаться на defaults API/CLI — **заполнить все поля** из таблицы (включая явные `draft` / `prerelease` / `target` / `name` / `body`).
+
+Права: push в репо. Если `target_commitish` указывает на коммит, меняющий `.github/workflows/`, токену нужен scope `workflow` / permission Workflows (write); иначе часто **404** или **403**.
+
+---
+
+## 3. Generate release notes
+
+`POST /repos/{owner}/{repo}/releases/generate-notes` — **не** создаёт Release; возвращает `{ "name", "body" }`.
+
+| Поле | Назначение |
+|------|------------|
+| `tag_name` | **обязателен** |
+| `target_commitish` | нужен, если тега ещё нет |
+| `previous_tag_name` | явное начало диапазона notes |
+| `configuration_file_path` | иначе `.github/release.yml` / default |
+
+В CLI: `gh release create … --generate-notes` (+ `--notes` / `-F` prepend).
+
+Для flask_blog предпочтение: **body из CHANGELOG**; `--generate-notes` — дополнение, не замена, если CHANGELOG уже подготовлен.
+
+---
+
+## 4. Ответы и ошибки
+
+| Код | Когда |
+|-----|--------|
+| **201** | Create OK (`html_url`, `upload_url`, `id`, `tag_name`, …) |
+| **200** | Get / list / update / generate-notes |
+| **204** | Delete |
+| **404** | Нет ресурса; неверная discussion category; workflow-permission edge case |
+| **401** | Нет/битый auth |
+| **403** | Нет доступа (в т.ч. integration / workflows) |
+| **422** | Validation / spam / дубликат asset name при upload |
+
+Вторичный rate limit — при частых create (notifications).
+
+Ключевые поля ответа Release: `id`, `tag_name`, `target_commitish`, `name`, `body`, `draft`, `prerelease`, `html_url`, `upload_url`, `tarball_url`, `zipball_url`, `assets[]`.
+
+---
+
+## 5. Assets
+
+- Upload: host **`uploads.github.com`**, raw binary body, query `name=` (обязателен), опционально `label=`.
+- URL берётся из `upload_url` ответа create (hypermedia).
+- Дубликат имени файла → **422**; пустой asset после сбоя upload можно удалить.
+- Скачать бинарь: `Accept: application/octet-stream` или `browser_download_url`.
+
+Для flask_blog (PythonAnywhere / source deploy) assets обычно **не нужны** — достаточно tag + notes.
+
+---
+
+## 6. CLI ↔ API
+
+| Цель | `gh` | REST |
+|------|------|------|
+| Создать | `gh release create <tag> …` | `POST …/releases` |
+| Notes из файла | `-F path` / `-n` | `body` |
+| Title | `-t` / `--title` | `name` |
+| Target | `--target main` | `target_commitish` |
+| Draft | `--draft` | `draft: true` |
+| Prerelease | `--prerelease` | `prerelease: true` |
+| Latest | `--latest` / `--latest=false` | `make_latest` |
+| Auto notes | `--generate-notes` | `generate_release_notes: true` |
+| Проверка | `gh release view <tag>` | `GET …/releases/tags/{tag}` |
+
+Пример (все поля явно — канон проекта):
+
+```bash
+TAG=v0.4.0
+gh release create "$TAG" \
+  --title "Flask Blog 0.4.0" \
+  --notes-file /tmp/release-body.md \
+  --target main \
+  --latest
+# без --draft и без --prerelease → published full release
+```
+
+Эквивалент через API:
+
+```bash
+gh api repos/{owner}/{repo}/releases -f tag_name="$TAG" \
+  -f target_commitish=main \
+  -f name="Flask Blog 0.4.0" \
+  -f body="$(cat /tmp/release-body.md)" \
+  -F draft=false \
+  -F prerelease=false \
+  -F generate_release_notes=false \
+  -f make_latest=true
+```


### PR DESCRIPTION
## Summary
- Добавлены `docs/RELEASE.md` и `docs/github-releases-api.md` — канон релиза и справка GitHub Releases API
- Skill `flask-blog-git-release`: при «релиз» / «релиз в main» заполняются все поля Release
- Обновлены связанные skills и индексы docs/AGENTS

## Test plan
- [ ] Проверить ссылки в `docs/README.md` и `AGENTS.md`
- [ ] Убедиться, что `flask-blog-git-release` требует tag/name/body/target/draft/prerelease/latest


Made with [Cursor](https://cursor.com)