### PR TITLE
fix: safe login next redirect (#55)

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -21,6 +21,7 @@ from app.auth.helpers import (
     login_user,
     logout_user,
     parse_tag,
+    safe_next_url,
 )
 from app.csrf import validate_csrf
 from app.db import execute, query_one
@@ -144,8 +145,11 @@ def login():
         if error is None and user is not None:
             login_user(user["id"])
             flash(f"С возвращением, {format_tag(user['name'], user['discriminator'])}!", "success")
-            next_url = request.args.get("next")
-            return redirect(next_url or url_for("posts.index"))
+            next_url = safe_next_url(
+                request.args.get("next"),
+                default=url_for("posts.index"),
+            )
+            return redirect(next_url)
 
         flash(error or "Ошибка входа.", "danger")
 

--- a/app/auth/helpers.py
+++ b/app/auth/helpers.py
@@ -7,6 +7,7 @@ import re
 from collections.abc import Callable
 from functools import wraps
 from typing import Any, TypeVar
+from urllib.parse import urlparse
 
 from flask import flash, g, redirect, session, url_for
 
@@ -16,6 +17,28 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 RESERVED_USERNAME = "admin"
 TAG_RE = re.compile(r"^([^#]+)#(\d{4})$")
+
+
+def safe_next_url(target: str | None, *, default: str) -> str:
+    """Вернуть ``target``, если это безопасный относительный путь; иначе ``default``.
+
+    Политика (whitelist relative): только path, начинающийся с одного ``/``.
+    Отклоняются внешние URL, ``//…`` (protocol-relative), scheme, netloc,
+    backslash и управляющие символы в Location.
+    """
+    if not target:
+        return default
+    candidate = target.strip()
+    if not candidate:
+        return default
+    if "\\" in candidate or "\n" in candidate or "\r" in candidate:
+        return default
+    if not candidate.startswith("/") or candidate.startswith("//"):
+        return default
+    parsed = urlparse(candidate)
+    if parsed.scheme or parsed.netloc:
+        return default
+    return candidate
 
 
 def parse_tag(value: str) -> tuple[str, str] | None:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@
 1. `before_request`: `load_logged_in_user` → `g.user` из `session["user_id"]` (или `None`).
 2. Шаблоны: `csrf_token`, `current_year` (context processor).
 3. Контент на витрине: фильтры `render_content` / `plain_excerpt` (`app/content_render.py` + nh3), не сырой `| safe` из БД. Страницы `/` и `/posts/<id>`: Open Graph / Twitter Card meta (`og:*`, `twitter:*`); description из `plain_excerpt`, image — `first_markdown_image_url` или `static/img/og-default.jpg`.
-4. Login: cookie session; без JWT. Deploy-hook: Bearer `DEPLOY_SECRET` (не user-auth).
+4. Login: cookie session; без JWT. Query `next` после login — только через `safe_next_url` (whitelist relative `/…`; внешние и `//…` → home). Deploy-hook: Bearer `DEPLOY_SECRET` (не user-auth).
 
 ## Права
 

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -39,7 +39,7 @@ CSRF-токен и `validate_csrf()` есть только на login/register. 
 
 ## Auth: безопасный redirect `next` после login
 
-**Статус:** in_progress
+**Статус:** in_review
 **GitHub:** #55
 **Приоритет:** P0
 **Категория:** Auth / Security

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -39,7 +39,7 @@ CSRF-токен и `validate_csrf()` есть только на login/register. 
 
 ## Auth: безопасный redirect `next` после login
 
-**Статус:** open
+**Статус:** in_progress
 **GitHub:** #55
 **Приоритет:** P0
 **Категория:** Auth / Security
@@ -56,9 +56,9 @@ CSRF-токен и `validate_csrf()` есть только на login/register. 
 
 ### Подзадачи
 
-- [ ] Хелпер валидации `next` (whitelist relative)
-- [ ] Подключить в login view
-- [ ] Тесты open-redirect negatives
+- [x] Хелпер валидации `next` (whitelist relative)
+- [x] Подключить в login view
+- [x] Тесты open-redirect negatives
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Login: параметр `next` валидируется (`safe_next_url`) — open redirect на внешние/`//…` URL закрыт; fallback на home.
+
 ### Docs
 
 - DEPLOY.md / DEVELOPMENT.md: обязательность `.env` на проде; локальный `flask run --debug` и CLI без debug.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -85,6 +85,58 @@ class AuthTests(BlogTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"admin#0001", response.data)
 
+    def test_login_safe_next_relative_path(self) -> None:
+        self.register("nextok", "secret1")
+        tag = self.user_tag("nextok")
+        self.client.get("/auth/logout", follow_redirects=True)
+        token = self.csrf_token()
+        response = self.client.post(
+            "/auth/login?next=/users/",
+            data={"tag": tag, "password": "secret1", "csrf_token": token},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers["Location"], "/users/")
+
+    def test_login_rejects_open_redirect_next(self) -> None:
+        self.register("nextev", "secret1")
+        tag = self.user_tag("nextev")
+        self.client.get("/auth/logout", follow_redirects=True)
+        token = self.csrf_token()
+        for evil in (
+            "https://evil.example/",
+            "//evil.example/phish",
+            "http://evil.example",
+            "\\\\evil.example",
+        ):
+            with self.subTest(next=evil):
+                response = self.client.post(
+                    f"/auth/login?next={evil}",
+                    data={"tag": tag, "password": "secret1", "csrf_token": token},
+                )
+                self.assertEqual(response.status_code, 302)
+                location = response.headers["Location"]
+                self.assertFalse(
+                    location.startswith("http") or location.startswith("//"),
+                    msg=f"open redirect to {location!r}",
+                )
+                self.assertEqual(location, "/")
+                self.client.get("/auth/logout", follow_redirects=True)
+                token = self.csrf_token()
+
+    def test_safe_next_url_helper(self) -> None:
+        from app.auth.helpers import safe_next_url
+
+        default = "/fallback"
+        self.assertEqual(safe_next_url("/posts/1", default=default), "/posts/1")
+        self.assertEqual(safe_next_url("/users/?tab=1", default=default), "/users/?tab=1")
+        self.assertEqual(safe_next_url(None, default=default), default)
+        self.assertEqual(safe_next_url("", default=default), default)
+        self.assertEqual(safe_next_url("https://evil.test/", default=default), default)
+        self.assertEqual(safe_next_url("//evil.test/", default=default), default)
+        self.assertEqual(safe_next_url("evil.test", default=default), default)
+        self.assertEqual(safe_next_url("/\\evil.test", default=default), default)
+        self.assertEqual(safe_next_url("javascript:alert(1)", default=default), default)
+
     def test_logout(self) -> None:
         self.register("carol", "secret1")
         response = self.client.get("/auth/logout", follow_redirects=True)


### PR DESCRIPTION
## Summary
- Validate `next` after login via `safe_next_url` (relative `/…` only).
- Reject external and protocol-relative (`//…`) URLs; fall back to home.
- Unit tests for allowed and open-redirect negative cases.

Closes #55

## Test plan
- [x] `python -m unittest discover -s tests -v`
- [x] IronBee: login with `next=https://evil…` / `//evil…` → `/`; `next=/users/` → `/users/`


Made with [Cursor](https://cursor.com)