### PR TITLE
fix: CSRF on mutating POST and logout (#54)

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -144,7 +144,7 @@ def login():
 
         if error is None and user is not None:
             login_user(user["id"])
-            flash(f"С возвращением, {format_tag(user['name'], user['discriminator'])}!", "success")
+            flash(f"С возвращением, {format_tag(user['name'], user['discriminator'])}", "success")
             next_url = safe_next_url(
                 request.args.get("next"),
                 default=url_for("posts.index"),
@@ -156,9 +156,14 @@ def login():
     return render_template("auth/login.html")
 
 
-@bp.route("/logout")
+@bp.route("/logout", methods=("GET", "POST"))
 def logout():
-    """Clear session and redirect home."""
+    """POST: clear session (CSRF required). GET: redirect only, no side-effect."""
+    if request.method == "GET":
+        return redirect(url_for("posts.index"))
+    if not validate_csrf():
+        flash("Сессия устарела. Обновите страницу и попробуйте снова.", "danger")
+        return redirect(url_for("posts.index"))
     logout_user()
     flash("Вы вышли.", "info")
     return redirect(url_for("posts.index"))

--- a/app/comments/__init__.py
+++ b/app/comments/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from flask import Blueprint, abort, flash, g, redirect, request, url_for
+from flask import Blueprint, abort, flash, g, redirect, render_template, request, url_for
 
 from app.auth.helpers import is_owner_or_admin, login_required
+from app.csrf import validate_csrf
 from app.db import execute, query_one
 
 bp = Blueprint("comments", __name__)
@@ -17,6 +18,8 @@ _BODY_FORMAT = "markdown"
 @login_required
 def create(post_id: int):
     """Add a comment to a post."""
+    if not validate_csrf():
+        abort(403)
     post = query_one("SELECT id FROM posts WHERE id = ?", (post_id,))
     if post is None:
         abort(404)
@@ -39,8 +42,6 @@ def create(post_id: int):
 @login_required
 def edit(comment_id: int):
     """Edit own comment (or any as admin)."""
-    from flask import render_template
-
     comment = query_one("SELECT * FROM comments WHERE id = ?", (comment_id,))
     if comment is None:
         abort(404)
@@ -48,6 +49,8 @@ def edit(comment_id: int):
         abort(403)
 
     if request.method == "POST":
+        if not validate_csrf():
+            abort(403)
         body_source = (request.form.get("body_source") or "").strip()
         if not body_source:
             flash("Комментарий не может быть пустым.", "danger")
@@ -70,6 +73,8 @@ def edit(comment_id: int):
 @login_required
 def delete(comment_id: int):
     """Delete own comment (or any as admin)."""
+    if not validate_csrf():
+        abort(403)
     comment = query_one("SELECT * FROM comments WHERE id = ?", (comment_id,))
     if comment is None:
         abort(404)

--- a/app/posts/__init__.py
+++ b/app/posts/__init__.py
@@ -6,6 +6,7 @@ from flask import Blueprint, abort, flash, g, jsonify, redirect, render_template
 
 from app.auth.helpers import is_owner_or_admin, login_required
 from app.content_render import first_markdown_image_url, plain_excerpt, render_to_html
+from app.csrf import validate_csrf
 from app.db import execute, query_all, query_one
 
 bp = Blueprint("posts", __name__)
@@ -92,6 +93,8 @@ def detail(post_id: int):
 def create():
     """Create a post."""
     if request.method == "POST":
+        if not validate_csrf():
+            abort(403)
         title = (request.form.get("title") or "").strip()
         body_source = (request.form.get("body_source") or "").strip()
         error = _validate_post(title, body_source)
@@ -121,6 +124,9 @@ def edit(post_id: int):
         abort(403)
 
     if request.method == "POST":
+        if not validate_csrf():
+            abort(403)
+
         title = (request.form.get("title") or "").strip()
         body_source = (request.form.get("body_source") or "").strip()
         error = _validate_post(title, body_source)
@@ -146,6 +152,8 @@ def edit(post_id: int):
 @login_required
 def delete(post_id: int):
     """Delete own post (or any as admin). Comments cascade."""
+    if not validate_csrf():
+        abort(403)
     post = query_one("SELECT * FROM posts WHERE id = ?", (post_id,))
     if post is None:
         abort(404)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -69,7 +69,10 @@
           <a class="nav-link p-0 user-tag" href="{{ url_for('users.detail', user_id=g.user['id']) }}">
             {{ g.user['name'] }}#{{ g.user['discriminator'] }}
           </a>
-          <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('auth.logout') }}">Выйти</a>
+          <form class="d-inline" method="post" action="{{ url_for('auth.logout') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-outline-secondary btn-sm">Выйти</button>
+          </form>
           {% else %}
           <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('auth.login') }}">Войти</a>
           <a class="btn btn-dark btn-sm" href="{{ url_for('auth.register') }}">Регистрация</a>

--- a/app/templates/comments/edit.html
+++ b/app/templates/comments/edit.html
@@ -15,6 +15,7 @@
             <textarea class="form-control js-markdown-editor" id="body_source" name="body_source" rows="4" required>{{ comment['body_source'] }}</textarea>
           </div>
           <div class="d-flex flex-wrap gap-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-dark">Сохранить</button>
             <a class="btn btn-outline-secondary" href="{{ url_for('posts.detail', post_id=comment['post_id']) }}">Отмена</a>
           </div>

--- a/app/templates/posts/detail.html
+++ b/app/templates/posts/detail.html
@@ -47,6 +47,7 @@
         <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('posts.edit', post_id=post['id']) }}">Редактировать</a>
         <form method="post" action="{{ url_for('posts.delete', post_id=post['id']) }}"
               onsubmit="return confirm('Удалить статью?');">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <button type="submit" class="btn btn-outline-danger btn-sm">Удалить</button>
         </form>
       </div>
@@ -77,6 +78,7 @@
                 <a class="small link-secondary text-decoration-none" href="{{ url_for('comments.edit', comment_id=c['id']) }}">Изменить</a>
                 <form method="post" action="{{ url_for('comments.delete', comment_id=c['id']) }}"
                       onsubmit="return confirm('Удалить комментарий?');">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <button type="submit" class="btn btn-link btn-sm p-0 link-danger text-decoration-none">Удалить</button>
                 </form>
               </div>
@@ -95,6 +97,7 @@
       <div class="card border">
         <div class="card-body p-3 p-md-4">
           <form method="post" action="{{ url_for('comments.create', post_id=post['id']) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <label class="form-label" for="body_source">Ваш комментарий</label>
             <textarea class="form-control js-markdown-editor" id="body_source" name="body_source" rows="3" required
                       placeholder="Напишите комментарий…"></textarea>

--- a/app/templates/posts/form.html
+++ b/app/templates/posts/form.html
@@ -10,6 +10,7 @@
     <div class="card border">
       <div class="card-body p-3 p-md-4">
         <form method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <div class="mb-3">
             <label class="form-label" for="title">Заголовок</label>
             <input class="form-control" type="text" id="title" name="title" maxlength="200" required

--- a/app/templates/users/edit.html
+++ b/app/templates/users/edit.html
@@ -7,6 +7,7 @@
     <div class="card border">
       <div class="card-body p-3 p-md-4">
         <form method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <div class="mb-3">
             <label class="form-label" for="password">Новый пароль</label>
             <input class="form-control" type="password" id="password" name="password"

--- a/app/templates/users/index.html
+++ b/app/templates/users/index.html
@@ -32,6 +32,7 @@
                 {% if u['id'] != g.user['id'] %}
                 <form class="d-inline" method="post" action="{{ url_for('users.delete', user_id=u['id']) }}"
                       onsubmit="return confirm('Удалить пользователя?');">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <button type="submit" class="btn btn-outline-danger btn-sm">Удалить</button>
                 </form>
                 {% endif %}

--- a/app/users/__init__.py
+++ b/app/users/__init__.py
@@ -6,6 +6,7 @@ from flask import Blueprint, abort, flash, g, redirect, render_template, request
 from werkzeug.security import generate_password_hash
 
 from app.auth.helpers import admin_required, format_tag, login_required
+from app.csrf import validate_csrf
 from app.db import execute, query_all, query_one
 
 bp = Blueprint("users", __name__, url_prefix="/users")
@@ -44,6 +45,8 @@ def edit(user_id: int):
         abort(403)
 
     if request.method == "POST":
+        if not validate_csrf():
+            abort(403)
         password = request.form.get("password") or ""
         if password:
             if len(password) < 6:
@@ -86,6 +89,8 @@ def edit(user_id: int):
 @admin_required
 def delete(user_id: int):
     """Admin: delete a user (not the last admin)."""
+    if not validate_csrf():
+        abort(403)
     user = query_one("SELECT * FROM users WHERE id = ?", (user_id,))
     if user is None:
         abort(404)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@
 | GET, POST | `/auth/register` | auth |
 | GET | `/auth/register/success` | auth |
 | GET, POST | `/auth/login` | auth |
-| GET | `/auth/logout` | auth |
+| GET, POST | `/auth/logout` | auth |
 | GET | `/` | posts |
 | GET | `/posts/<id>` | posts |
 | GET, POST | `/posts/new` | posts |
@@ -49,7 +49,7 @@
 ## Поток запроса
 
 1. `before_request`: `load_logged_in_user` → `g.user` из `session["user_id"]` (или `None`).
-2. Шаблоны: `csrf_token`, `current_year` (context processor).
+2. Шаблоны: `csrf_token`, `current_year` (context processor). Mutating POST (auth login/register/logout, posts/comments/users CRUD) проверяют `validate_csrf()`; скрытое поле `csrf_token` в формах. `GET /auth/logout` — только redirect, без очистки сессии.
 3. Контент на витрине: фильтры `render_content` / `plain_excerpt` (`app/content_render.py` + nh3), не сырой `| safe` из БД. Страницы `/` и `/posts/<id>`: Open Graph / Twitter Card meta (`og:*`, `twitter:*`); description из `plain_excerpt`, image — `first_markdown_image_url` или `static/img/og-default.jpg`.
 4. Login: cookie session; без JWT. Query `next` после login — только через `safe_next_url` (whitelist relative `/…`; внешние и `//…` → home). Deploy-hook: Bearer `DEPLOY_SECRET` (не user-auth).
 

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -13,7 +13,7 @@
 
 ## Auth: CSRF на все mutating POST
 
-**Статус:** open
+**Статус:** in_progress
 **GitHub:** #54
 **Приоритет:** P0
 **Категория:** Auth / Security
@@ -30,10 +30,10 @@ CSRF-токен и `validate_csrf()` есть только на login/register. 
 
 ### Подзадачи
 
-- [ ] CSRF на CRUD постов
-- [ ] CSRF на CRUD комментариев
-- [ ] CSRF на admin users CRUD
-- [ ] Logout перевести на POST + CSRF (убрать GET-logout или оставить redirect-only без side-effect)
+- [x] CSRF на CRUD постов
+- [x] CSRF на CRUD комментариев
+- [x] CSRF на admin users CRUD
+- [x] Logout перевести на POST + CSRF (убрать GET-logout или оставить redirect-only без side-effect)
 
 ---
 

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -13,7 +13,7 @@
 
 ## Auth: CSRF на все mutating POST
 
-**Статус:** in_progress
+**Статус:** in_review
 **GitHub:** #54
 **Приоритет:** P0
 **Категория:** Auth / Security

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,9 +9,12 @@
 
 ### Added
 
+- CSRF на все mutating POST: posts/comments/users CRUD + logout (`validate_csrf`, скрытое поле в формах). Unit-тесты на отказ без/с неверным токеном.
 - Guard в `create_app`: в non-debug режиме отказ старта при известных небезопасных дефолтах `SECRET_KEY=dev-change-me` / `ADMIN_PASSWORD=admin` (`RuntimeError` + critical в лог). Debug/testing по-прежнему допускают дефолты.
 
 ### Changed
+
+- Logout: `POST /auth/logout` с CSRF; `GET /auth/logout` только redirect без side-effect. В навбаре — форма «Выйти».
 
 ### Fixed
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -79,7 +79,7 @@ python -m unittest discover -s tests -v
 
 В GitHub Actions: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) на `push`/`pull_request` в `main` и `dev`. Деплой на PythonAnywhere ([`deploy.yml`](../.github/workflows/deploy.yml)) на `main` идёт только после успешного того же прогона.
 
-**Вручную в браузере** (по необходимости, в т.ч. auth / password manager): регистрация → **Save** на ключике с полным `name#NNNN` → logout → login через предложение браузера (autofill). Агент не гоняет Playwright/CDP-скрипты для этого.
+**Вручную в браузере** (по необходимости, в т.ч. auth / password manager): регистрация → **Save** на ключике с полным `name#NNNN` → logout (`POST` с CSRF из навбара; `GET /auth/logout` сессию не чистит) → login через предложение браузера (autofill). Агент не гоняет Playwright/CDP-скрипты для этого.
 
 ## IronBee DevTools (опционально)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -58,6 +58,18 @@ class BlogTestCase(unittest.TestCase):
     def login_admin(self):
         return self.login("admin#0001", self.app.config["ADMIN_PASSWORD"])
 
+    def logout(self, *, follow_redirects: bool = True):
+        """POST logout with CSRF (GET no longer clears the session)."""
+        return self.client.post(
+            "/auth/logout",
+            data=self.csrf_data(),
+            follow_redirects=follow_redirects,
+        )
+
+    def csrf_data(self, **fields) -> dict:
+        """Form POST payload with a fresh CSRF token."""
+        return {**fields, "csrf_token": self.csrf_token()}
+
     def user_tag(self, name: str) -> str:
         row = get_db().execute(
             "SELECT name, discriminator FROM users WHERE name = ? COLLATE NOCASE",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,7 +15,7 @@ class AuthTests(BlogTestCase):
         self.assertNotIn(b'value="secret1"', response.data)
         self.assertNotIn(b"PasswordCredential", response.data)
 
-        self.client.get("/auth/logout", follow_redirects=True)
+        self.logout()
         tag = self.user_tag("bob")
         response = self.login(tag, "secret1")
         self.assertIn(b"bob#", response.data)
@@ -62,7 +62,7 @@ class AuthTests(BlogTestCase):
     def test_login_accepts_username_field_name(self) -> None:
         self.register("fieldname", "secret1")
         tag = self.user_tag("fieldname")
-        self.client.get("/auth/logout", follow_redirects=True)
+        self.logout()
         token = self.csrf_token()
         response = self.client.post(
             "/auth/login",
@@ -88,7 +88,7 @@ class AuthTests(BlogTestCase):
     def test_login_safe_next_relative_path(self) -> None:
         self.register("nextok", "secret1")
         tag = self.user_tag("nextok")
-        self.client.get("/auth/logout", follow_redirects=True)
+        self.logout()
         token = self.csrf_token()
         response = self.client.post(
             "/auth/login?next=/users/",
@@ -100,7 +100,7 @@ class AuthTests(BlogTestCase):
     def test_login_rejects_open_redirect_next(self) -> None:
         self.register("nextev", "secret1")
         tag = self.user_tag("nextev")
-        self.client.get("/auth/logout", follow_redirects=True)
+        self.logout()
         token = self.csrf_token()
         for evil in (
             "https://evil.example/",
@@ -120,7 +120,7 @@ class AuthTests(BlogTestCase):
                     msg=f"open redirect to {location!r}",
                 )
                 self.assertEqual(location, "/")
-                self.client.get("/auth/logout", follow_redirects=True)
+                self.logout()
                 token = self.csrf_token()
 
     def test_safe_next_url_helper(self) -> None:
@@ -139,9 +139,23 @@ class AuthTests(BlogTestCase):
 
     def test_logout(self) -> None:
         self.register("carol", "secret1")
-        response = self.client.get("/auth/logout", follow_redirects=True)
+        response = self.logout()
         self.assertIn("Вы вышли".encode(), response.data)
         self.assertNotIn(b"carol#", response.data)
+
+    def test_logout_get_has_no_side_effect(self) -> None:
+        self.register("getlogout", "secret1")
+        response = self.client.get("/auth/logout", follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Вы вышли".encode(), response.data)
+        self.assertIn(b"getlogout#", response.data)
+
+    def test_logout_rejects_missing_csrf(self) -> None:
+        self.register("csrfout", "secret1")
+        response = self.client.post("/auth/logout", data={})
+        self.assertEqual(response.status_code, 302)
+        home = self.client.get("/")
+        self.assertIn(b"csrfout#", home.data)
 
     def test_profile_self(self) -> None:
         self.register("dave", "secret1")
@@ -154,8 +168,29 @@ class AuthTests(BlogTestCase):
         response = self.client.get("/users/")
         self.assertEqual(response.status_code, 302)
 
-        self.client.get("/auth/logout")
+        self.logout()
         self.login_admin()
         response = self.client.get("/users/")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"eve#", response.data)
+
+    def test_users_edit_rejects_missing_csrf(self) -> None:
+        self.register("editme", "secret1")
+        user = query_one("SELECT id FROM users WHERE name = ?", ("editme",))
+        response = self.client.post(
+            f"/users/{user['id']}/edit",
+            data={"password": "secret2"},
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_users_delete_rejects_bad_csrf(self) -> None:
+        self.register("victim", "secret1")
+        victim = query_one("SELECT id FROM users WHERE name = ?", ("victim",))
+        self.logout()
+        self.login_admin()
+        response = self.client.post(
+            f"/users/{victim['id']}/delete",
+            data={"csrf_token": "not-the-real-token"},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertIsNotNone(query_one("SELECT id FROM users WHERE id = ?", (victim["id"],)))

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -9,7 +9,10 @@ from tests import BlogTestCase
 class CommentsTests(BlogTestCase):
     def _make_post(self) -> int:
         self.register("author", "secret1")
-        self.client.post("/posts/new", data={"title": "Post", "body_source": "Body"})
+        self.client.post(
+            "/posts/new",
+            data=self.csrf_data(title="Post", body_source="Body"),
+        )
         post = query_one("SELECT id FROM posts WHERE title = ?", ("Post",))
         assert post is not None
         return int(post["id"])
@@ -18,16 +21,27 @@ class CommentsTests(BlogTestCase):
         post_id = self._make_post()
         response = self.client.post(
             f"/posts/{post_id}/comments",
-            data={"body_source": "Nice post"},
+            data=self.csrf_data(body_source="Nice post"),
             follow_redirects=True,
         )
         self.assertIn(b"Nice post", response.data)
+
+    def test_create_rejects_missing_csrf(self) -> None:
+        post_id = self._make_post()
+        response = self.client.post(
+            f"/posts/{post_id}/comments",
+            data={"body_source": "No CSRF"},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertIsNone(
+            query_one("SELECT id FROM comments WHERE body_source = ?", ("No CSRF",))
+        )
 
     def test_edit_own_comment(self) -> None:
         post_id = self._make_post()
         self.client.post(
             f"/posts/{post_id}/comments",
-            data={"body_source": "v1"},
+            data=self.csrf_data(body_source="v1"),
         )
         comment = query_one(
             "SELECT id FROM comments WHERE body_source = ?",
@@ -35,7 +49,7 @@ class CommentsTests(BlogTestCase):
         )
         response = self.client.post(
             f"/comments/{comment['id']}/edit",
-            data={"body_source": "v2"},
+            data=self.csrf_data(body_source="v2"),
             follow_redirects=True,
         )
         self.assertIn(b"v2", response.data)
@@ -44,24 +58,31 @@ class CommentsTests(BlogTestCase):
         post_id = self._make_post()
         self.client.post(
             f"/posts/{post_id}/comments",
-            data={"body_source": "mine"},
+            data=self.csrf_data(body_source="mine"),
         )
         comment = query_one(
             "SELECT id FROM comments WHERE body_source = ?",
             ("mine",),
         )
-        self.client.get("/auth/logout")
+        self.logout()
         self.register("stranger", "secret1")
-        response = self.client.post(f"/comments/{comment['id']}/delete")
+        response = self.client.post(
+            f"/comments/{comment['id']}/delete",
+            data=self.csrf_data(),
+        )
         self.assertEqual(response.status_code, 403)
 
     def test_delete_post_cascades_comments(self) -> None:
         post_id = self._make_post()
         self.client.post(
             f"/posts/{post_id}/comments",
-            data={"body_source": "bye"},
+            data=self.csrf_data(body_source="bye"),
         )
-        self.client.post(f"/posts/{post_id}/delete", follow_redirects=True)
+        self.client.post(
+            f"/posts/{post_id}/delete",
+            data=self.csrf_data(),
+            follow_redirects=True,
+        )
         self.assertIsNone(
             query_one("SELECT id FROM comments WHERE post_id = ?", (post_id,))
         )
@@ -70,7 +91,7 @@ class CommentsTests(BlogTestCase):
         post_id = self._make_post()
         self.client.post(
             f"/posts/{post_id}/comments",
-            data={"body_source": "See **this**"},
+            data=self.csrf_data(body_source="See **this**"),
         )
         row = query_one(
             "SELECT body_format FROM comments WHERE body_source = ?",
@@ -85,7 +106,7 @@ class CommentsTests(BlogTestCase):
         post_id = self._make_post()
         self.client.post(
             f"/posts/{post_id}/comments",
-            data={"body_source": "c1", "body_format": "html"},
+            data=self.csrf_data(body_source="c1", body_format="html"),
         )
         row = query_one(
             "SELECT body_format FROM comments WHERE body_source = ?",

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -11,7 +11,7 @@ class PostsTests(BlogTestCase):
         self.register("writer", "secret1")
         response = self.client.post(
             "/posts/new",
-            data={"title": "Hello", "body_source": "World body"},
+            data=self.csrf_data(title="Hello", body_source="World body"),
             follow_redirects=True,
         )
         self.assertEqual(response.status_code, 200)
@@ -21,37 +21,47 @@ class PostsTests(BlogTestCase):
         self.assertIn(b"Hello", home.data)
         self.assertIn(b"writer#", home.data)
 
+    def test_create_rejects_missing_csrf(self) -> None:
+        self.register("writer", "secret1")
+        response = self.client.post(
+            "/posts/new",
+            data={"title": "No CSRF", "body_source": "Nope"},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertIsNone(query_one("SELECT id FROM posts WHERE title = ?", ("No CSRF",)))
+
     def test_edit_own_post(self) -> None:
         self.register("writer", "secret1")
-        self.client.post("/posts/new", data={"title": "T1", "body_source": "B1"})
+        self.client.post("/posts/new", data=self.csrf_data(title="T1", body_source="B1"))
         post = query_one("SELECT id FROM posts WHERE title = ?", ("T1",))
         response = self.client.post(
             f"/posts/{post['id']}/edit",
-            data={"title": "T2", "body_source": "B2"},
+            data=self.csrf_data(title="T2", body_source="B2"),
             follow_redirects=True,
         )
         self.assertIn(b"T2", response.data)
 
     def test_cannot_edit_others(self) -> None:
         self.register("owner", "secret1")
-        self.client.post("/posts/new", data={"title": "Mine", "body_source": "Secret"})
+        self.client.post("/posts/new", data=self.csrf_data(title="Mine", body_source="Secret"))
         post = query_one("SELECT id FROM posts WHERE title = ?", ("Mine",))
-        self.client.get("/auth/logout")
+        self.logout()
         self.register("other", "secret1")
         response = self.client.post(
             f"/posts/{post['id']}/edit",
-            data={"title": "Hijack", "body_source": "Nope"},
+            data=self.csrf_data(title="Hijack", body_source="Nope"),
         )
         self.assertEqual(response.status_code, 403)
 
     def test_admin_can_delete_any(self) -> None:
         self.register("owner", "secret1")
-        self.client.post("/posts/new", data={"title": "Gone", "body_source": "Soon"})
+        self.client.post("/posts/new", data=self.csrf_data(title="Gone", body_source="Soon"))
         post = query_one("SELECT id FROM posts WHERE title = ?", ("Gone",))
-        self.client.get("/auth/logout")
+        self.logout()
         self.login_admin()
         response = self.client.post(
             f"/posts/{post['id']}/delete",
+            data=self.csrf_data(),
             follow_redirects=True,
         )
         self.assertEqual(response.status_code, 200)
@@ -61,7 +71,7 @@ class PostsTests(BlogTestCase):
         self.register("writer", "secret1")
         self.client.post(
             "/posts/new",
-            data={"title": "Md", "body_source": "Hello **bold**"},
+            data=self.csrf_data(title="Md", body_source="Hello **bold**"),
         )
         post = query_one("SELECT id, body_format FROM posts WHERE title = ?", ("Md",))
         self.assertEqual(post["body_format"], "markdown")
@@ -73,11 +83,11 @@ class PostsTests(BlogTestCase):
         self.register("writer", "secret1")
         self.client.post(
             "/posts/new",
-            data={
-                "title": "Fmt",
-                "body_source": "plain-looking",
-                "body_format": "html",
-            },
+            data=self.csrf_data(
+                title="Fmt",
+                body_source="plain-looking",
+                body_format="html",
+            ),
         )
         post = query_one(
             "SELECT body_format FROM posts WHERE title = ?",
@@ -89,10 +99,10 @@ class PostsTests(BlogTestCase):
         self.register("writer", "secret1")
         self.client.post(
             "/posts/new",
-            data={
-                "title": "Xss",
-                "body_source": "<script>alert(1)</script> **ok**",
-            },
+            data=self.csrf_data(
+                title="Xss",
+                body_source="<script>alert(1)</script> **ok**",
+            ),
         )
         post = query_one("SELECT id FROM posts WHERE title = ?", ("Xss",))
         detail = self.client.get(f"/posts/{post['id']}")
@@ -121,13 +131,13 @@ class PostsTests(BlogTestCase):
         self.register("writer", "secret1")
         self.client.post(
             "/posts/new",
-            data={
-                "title": "OG Title",
-                "body_source": (
+            data=self.csrf_data(
+                title="OG Title",
+                body_source=(
                     "Hello **world** and some more text for description.\n\n"
                     "![hero](https://cdn.example.com/cover.jpg)"
                 ),
-            },
+            ),
         )
         post = query_one("SELECT id FROM posts WHERE title = ?", ("OG Title",))
         detail = self.client.get(f"/posts/{post['id']}")
@@ -150,7 +160,7 @@ class PostsTests(BlogTestCase):
         self.register("writer", "secret1")
         self.client.post(
             "/posts/new",
-            data={"title": "No Img", "body_source": "Just text, no pictures."},
+            data=self.csrf_data(title="No Img", body_source="Just text, no pictures."),
         )
         post = query_one("SELECT id FROM posts WHERE title = ?", ("No Img",))
         detail = self.client.get(f"/posts/{post['id']}")


### PR DESCRIPTION
## Summary
- Require CSRF validation on posts/comments/users mutating POST endpoints and add hidden `csrf_token` fields to the corresponding forms.
- Switch logout to `POST /auth/logout` with CSRF; keep `GET /auth/logout` as redirect-only without clearing the session.
- Unit tests cover missing/invalid CSRF and the new logout behavior; docs/backlog #54 set to `in_review`.

## Test plan
- [x] `python -m unittest discover -s tests -v`
- [x] IronBee HTTP: POST `/posts/new` without CSRF → 403; with CSRF → 302
- [x] IronBee HTTP: GET `/auth/logout` keeps session; POST logout with CSRF logs out
- [x] Manual: create/edit/delete post and comment in browser via forms with CSRF
- [x] Manual: admin user edit/delete forms; navbar «Выйти» button

Closes #54

Made with [Cursor](https://cursor.com)