### PR TITLE
feat: explicit session TTL and remember-me (#59)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ DEPLOY_SECRET=
 
 # 1 на HTTPS (production); 0 или пусто для локального http://
 SESSION_COOKIE_SECURE=0
+
+# TTL permanent-сессии (не Flask-дефолт ~31 день).
+PERMANENT_SESSION_LIFETIME=14

--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,5 @@ DEPLOY_SECRET=
 # 1 на HTTPS (production); 0 или пусто для локального http://
 SESSION_COOKIE_SECURE=0
 
-# TTL permanent-сессии (не Flask-дефолт ~31 день).
-PERMANENT_SESSION_LIFETIME=14
+# TTL permanent-сессии в днях (дефолт в config — 30).
+PERMANENT_SESSION_LIFETIME_DAYS=30

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -88,7 +88,7 @@ def register():
                 """,
                 (name, discriminator, generate_password_hash(password)),
             )
-            login_user(user_id)
+            login_user(user_id, remember=True)
             tag = format_tag(name, discriminator)
             # Tag only — password stays in the browser for PasswordCredential.store.
             session[_PENDING_TAG_KEY] = tag
@@ -143,7 +143,8 @@ def login():
                 error = "Неверный логин или пароль."
 
         if error is None and user is not None:
-            login_user(user["id"])
+            remember = request.form.get("remember") == "1"
+            login_user(user["id"], remember=remember)
             flash(f"С возвращением, {format_tag(user['name'], user['discriminator'])}", "success")
             next_url = safe_next_url(
                 request.args.get("next"),

--- a/app/auth/helpers.py
+++ b/app/auth/helpers.py
@@ -82,11 +82,15 @@ def load_logged_in_user() -> None:
             session.pop("user_id", None)
 
 
-def login_user(user_id: int) -> None:
-    """Store user id in the session cookie and attach g.user."""
+def login_user(user_id: int, *, remember: bool = False) -> None:
+    """Сохранить ``user_id`` в cookie-сессии и выставить ``g.user``.
+
+    ``remember=True`` — permanent cookie с TTL из ``PERMANENT_SESSION_LIFETIME``.
+    ``remember=False`` — сессия до закрытия браузера (не permanent).
+    """
     session.clear()
     session["user_id"] = user_id
-    session.permanent = True
+    session.permanent = remember
     g.user = query_one("SELECT * FROM users WHERE id = ?", (user_id,))
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -17,7 +17,7 @@ INSECURE_DEFAULT_SECRET_KEY = "dev-change-me"
 INSECURE_DEFAULT_ADMIN_PASSWORD = "admin"
 
 # TTL для permanent-сессии («Запомнить меня»). Переопределение: дней через env.
-_DEFAULT_SESSION_DAYS = 14
+_DEFAULT_SESSION_DAYS = 30
 
 
 class Config:

--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from datetime import timedelta
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -14,6 +15,9 @@ load_dotenv(BASE_DIR / ".env")
 # Известные небезопасные дефолты — запрещены вне debug/testing (см. create_app).
 INSECURE_DEFAULT_SECRET_KEY = "dev-change-me"
 INSECURE_DEFAULT_ADMIN_PASSWORD = "admin"
+
+# TTL для permanent-сессии («Запомнить меня»). Переопределение: дней через env.
+_DEFAULT_SESSION_DAYS = 14
 
 
 class Config:
@@ -36,6 +40,15 @@ class Config:
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SAMESITE = "Lax"
     SESSION_COOKIE_SECURE = os.environ.get("SESSION_COOKIE_SECURE", "0") == "1"
+    # Явный TTL permanent-сессии (не Flask-дефолт ~31 день).
+    PERMANENT_SESSION_LIFETIME = timedelta(
+        days=int(
+            os.environ.get(
+                "PERMANENT_SESSION_LIFETIME_DAYS",
+                str(_DEFAULT_SESSION_DAYS),
+            )
+        )
+    )
 
 
 class TestConfig(Config):

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -14,10 +14,15 @@
                    placeholder="username#0001" required autocomplete="username">
             <div class="form-text">Формат Discord: имя#четыре цифры</div>
           </div>
-          <div class="mb-4">
+          <div class="mb-3">
             <label class="form-label" for="password">Пароль</label>
             <input class="form-control" type="password" id="password" name="password"
                    required autocomplete="current-password">
+          </div>
+          <div class="mb-4 form-check">
+            <input class="form-check-input" type="checkbox" value="1"
+                   id="remember" name="remember">
+            <label class="form-check-label" for="remember">Запомнить меня</label>
           </div>
           <div class="d-grid gap-2">
             <button type="submit" class="btn btn-dark">Войти</button>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@
 1. `before_request`: `load_logged_in_user` → `g.user` из `session["user_id"]` (или `None`).
 2. Шаблоны: `csrf_token`, `current_year` (context processor). Mutating POST (auth login/register/logout, posts/comments/users CRUD) проверяют `validate_csrf()`; скрытое поле `csrf_token` в формах. `GET /auth/logout` — только redirect, без очистки сессии.
 3. Контент на витрине: фильтры `render_content` / `plain_excerpt` (`app/content_render.py` + nh3), не сырой `| safe` из БД. Страницы `/` и `/posts/<id>`: Open Graph / Twitter Card meta (`og:*`, `twitter:*`); description из `plain_excerpt`, image — `first_markdown_image_url` или `static/img/og-default.jpg`.
-4. Login: cookie session; без JWT. Query `next` после login — только через `safe_next_url` (whitelist relative `/…`; внешние и `//…` → home). Deploy-hook: Bearer `DEPLOY_SECRET` (не user-auth).
+4. Login: cookie session; без JWT. Без «Запомнить меня» — сессия до закрытия браузера (`session.permanent=False`). С чекбоксом / после register — permanent с TTL `PERMANENT_SESSION_LIFETIME` (config, дефолт 14 дней; env `PERMANENT_SESSION_LIFETIME_DAYS`). Query `next` после login — только через `safe_next_url` (whitelist relative `/…`; внешние и `//…` → home). Deploy-hook: Bearer `DEPLOY_SECRET` (не user-auth).
 
 ## Права
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@
 1. `before_request`: `load_logged_in_user` → `g.user` из `session["user_id"]` (или `None`).
 2. Шаблоны: `csrf_token`, `current_year` (context processor). Mutating POST (auth login/register/logout, posts/comments/users CRUD) проверяют `validate_csrf()`; скрытое поле `csrf_token` в формах. `GET /auth/logout` — только redirect, без очистки сессии.
 3. Контент на витрине: фильтры `render_content` / `plain_excerpt` (`app/content_render.py` + nh3), не сырой `| safe` из БД. Страницы `/` и `/posts/<id>`: Open Graph / Twitter Card meta (`og:*`, `twitter:*`); description из `plain_excerpt`, image — `first_markdown_image_url` или `static/img/og-default.jpg`.
-4. Login: cookie session; без JWT. Без «Запомнить меня» — сессия до закрытия браузера (`session.permanent=False`). С чекбоксом / после register — permanent с TTL `PERMANENT_SESSION_LIFETIME` (config, дефолт 14 дней; env `PERMANENT_SESSION_LIFETIME_DAYS`). Query `next` после login — только через `safe_next_url` (whitelist relative `/…`; внешние и `//…` → home). Deploy-hook: Bearer `DEPLOY_SECRET` (не user-auth).
+4. Login: cookie session; без JWT. Без «Запомнить меня» — сессия до закрытия браузера (`session.permanent=False`). С чекбоксом / после register — permanent с TTL `PERMANENT_SESSION_LIFETIME` (config, дефолт 30 дней; env `PERMANENT_SESSION_LIFETIME_DAYS`). Query `next` после login — только через `safe_next_url` (whitelist relative `/…`; внешние и `//…` → home). Deploy-hook: Bearer `DEPLOY_SECRET` (не user-auth).
 
 ## Права
 

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -87,7 +87,7 @@
 
 ## Auth: явный TTL сессии
 
-**Статус:** open
+**Статус:** in_progress
 **GitHub:** #59
 **Приоритет:** P1
 **Категория:** Auth / Session
@@ -104,9 +104,9 @@
 
 ### Подзадачи
 
-- [ ] Константа TTL в config
-- [ ] Документация
-- [ ] (Опционально) remember-me checkbox
+- [x] Константа TTL в config
+- [x] Документация
+- [x] (Опционально) remember-me checkbox
 
 ---
 

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -87,7 +87,7 @@
 
 ## Auth: явный TTL сессии
 
-**Статус:** in_progress
+**Статус:** in_review
 **GitHub:** #59
 **Приоритет:** P1
 **Категория:** Auth / Session

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - CSRF на все mutating POST: posts/comments/users CRUD + logout (`validate_csrf`, скрытое поле в формах). Unit-тесты на отказ без/с неверным токеном.
 - Guard в `create_app`: в non-debug режиме отказ старта при известных небезопасных дефолтах `SECRET_KEY=dev-change-me` / `ADMIN_PASSWORD=admin` (`RuntimeError` + critical в лог). Debug/testing по-прежнему допускают дефолты.
-- Auth: явный `PERMANENT_SESSION_LIFETIME` (14 дней / `PERMANENT_SESSION_LIFETIME_DAYS`); чекбокс «Запомнить меня» на login; без него — сессия до закрытия браузера. Register остаётся permanent.
+- Auth: явный `PERMANENT_SESSION_LIFETIME` (30 дней / `PERMANENT_SESSION_LIFETIME_DAYS`); чекбокс «Запомнить меня» на login; без него — сессия до закрытия браузера. Register остаётся permanent.
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - CSRF на все mutating POST: posts/comments/users CRUD + logout (`validate_csrf`, скрытое поле в формах). Unit-тесты на отказ без/с неверным токеном.
 - Guard в `create_app`: в non-debug режиме отказ старта при известных небезопасных дефолтах `SECRET_KEY=dev-change-me` / `ADMIN_PASSWORD=admin` (`RuntimeError` + critical в лог). Debug/testing по-прежнему допускают дефолты.
+- Auth: явный `PERMANENT_SESSION_LIFETIME` (14 дней / `PERMANENT_SESSION_LIFETIME_DAYS`); чекбокс «Запомнить меня» на login; без него — сессия до закрытия браузера. Register остаётся permanent.
 
 ### Changed
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -81,7 +81,7 @@ python -m unittest discover -s tests -v
 
 **Вручную в браузере** (по необходимости, в т.ч. auth / password manager): регистрация → **Save** на ключике с полным `name#NNNN` → logout (`POST` с CSRF из навбара; `GET /auth/logout` сессию не чистит) → login через предложение браузера (autofill). Агент не гоняет Playwright/CDP-скрипты для этого.
 
-**Сессия (TTL):** `Config.PERMANENT_SESSION_LIFETIME` — явный срок permanent-cookie (дефолт 14 дней, override `PERMANENT_SESSION_LIFETIME_DAYS`). Login без чекбокса «Запомнить меня» — не permanent (до закрытия браузера); с чекбоксом или сразу после register — permanent. См. `app/config.py`, `login_user(..., remember=…)`.
+**Сессия (TTL):** `Config.PERMANENT_SESSION_LIFETIME` — явный срок permanent-cookie (дефолт 30 дней, override `PERMANENT_SESSION_LIFETIME_DAYS`). Login без чекбокса «Запомнить меня» — не permanent (до закрытия браузера); с чекбоксом или сразу после register — permanent. См. `app/config.py`, `login_user(..., remember=…)`.
 
 ## IronBee DevTools (опционально)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -81,6 +81,8 @@ python -m unittest discover -s tests -v
 
 **Вручную в браузере** (по необходимости, в т.ч. auth / password manager): регистрация → **Save** на ключике с полным `name#NNNN` → logout (`POST` с CSRF из навбара; `GET /auth/logout` сессию не чистит) → login через предложение браузера (autofill). Агент не гоняет Playwright/CDP-скрипты для этого.
 
+**Сессия (TTL):** `Config.PERMANENT_SESSION_LIFETIME` — явный срок permanent-cookie (дефолт 14 дней, override `PERMANENT_SESSION_LIFETIME_DAYS`). Login без чекбокса «Запомнить меня» — не permanent (до закрытия браузера); с чекбоксом или сразу после register — permanent. См. `app/config.py`, `login_user(..., remember=…)`.
+
 ## IronBee DevTools (опционально)
 
 | Настройка | Значение | Смысл |

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -71,6 +71,61 @@ class AuthTests(BlogTestCase):
         )
         self.assertIn(tag.encode(), response.data)
 
+    def test_permanent_session_lifetime_configured(self) -> None:
+        from datetime import timedelta
+
+        self.assertEqual(
+            self.app.config["PERMANENT_SESSION_LIFETIME"],
+            timedelta(days=14),
+        )
+
+    def test_login_default_is_non_permanent_session(self) -> None:
+        self.register("shortsess", "secret1")
+        tag = self.user_tag("shortsess")
+        self.logout()
+        token = self.csrf_token()
+        self.client.post(
+            "/auth/login",
+            data={"tag": tag, "password": "secret1", "csrf_token": token},
+        )
+        with self.client.session_transaction() as sess:
+            self.assertFalse(sess.permanent)
+            self.assertIsNotNone(sess.get("user_id"))
+
+    def test_login_remember_sets_permanent_session(self) -> None:
+        self.register("longsess", "secret1")
+        tag = self.user_tag("longsess")
+        self.logout()
+        token = self.csrf_token()
+        self.client.post(
+            "/auth/login",
+            data={
+                "tag": tag,
+                "password": "secret1",
+                "csrf_token": token,
+                "remember": "1",
+            },
+        )
+        with self.client.session_transaction() as sess:
+            self.assertTrue(sess.permanent)
+            self.assertIsNotNone(sess.get("user_id"))
+
+    def test_register_creates_permanent_session(self) -> None:
+        token = self.csrf_token()
+        self.client.post(
+            "/auth/register",
+            data={"name": "regperm", "password": "secret1", "csrf_token": token},
+        )
+        with self.client.session_transaction() as sess:
+            self.assertTrue(sess.permanent)
+            self.assertIsNotNone(sess.get("user_id"))
+
+    def test_login_form_has_remember_checkbox(self) -> None:
+        response = self.client.get("/auth/login")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'name="remember"', response.data)
+        self.assertIn("Запомнить меня".encode(), response.data)
+
     def test_reserved_admin_name(self) -> None:
         response = self.register("admin", "secret1")
         self.assertIn("зарезервировано".encode(), response.data)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -76,7 +76,7 @@ class AuthTests(BlogTestCase):
 
         self.assertEqual(
             self.app.config["PERMANENT_SESSION_LIFETIME"],
-            timedelta(days=14),
+            timedelta(days=30),
         )
 
     def test_login_default_is_non_permanent_session(self) -> None:


### PR DESCRIPTION
## Summary
- Explicit `PERMANENT_SESSION_LIFETIME` (default 30 days, override `PERMANENT_SESSION_LIFETIME_DAYS`)
- Login checkbox «Запомнить меня»: permanent cookie vs browser session
- Register keeps permanent session; docs/ARCHITECTURE/DEVELOPMENT/CHANGELOG updated

Closes #59

## Test plan
- [x] `python -m unittest tests.test_auth -v`
- [x] IronBee HTTP: login without remember → session cookie without Expires
- [x] IronBee HTTP: login with remember → Expires ≈ +30 days
- [ ] Manual: UI checkbox on `/auth/login`


Made with [Cursor](https://cursor.com)