### PR TITLE
docs: Conventional Commits-like task branch prefixes

### DIFF
--- a/.cursor/hooks/docs-after-task-stop.py
+++ b/.cursor/hooks/docs-after-task-stop.py
@@ -154,7 +154,7 @@ def main() -> int:
         return 0
 
     branch = git_out(root, "branch", "--show-current")
-    if not branch.startswith(("feat/", "fix/", "chore/")):
+    if not branch.startswith(("feat/", "fix/", "chore/", "refactor/", "test/")):
         print("{}")
         return 0
 

--- a/.cursor/rules/00-project.mdc
+++ b/.cursor/rules/00-project.mdc
@@ -40,6 +40,7 @@ alwaysApply: true
 |------|------|
 | Docs-first / scoping | `docs-context.mdc` |
 | Docs after task | skill `flask-blog-docs-after-task` + hook `stop` |
+| Имена task-веток | `git-branches.mdc` |
 | Post-merge `merged/*` | `git-merged-branches.mdc` + skill `flask-blog-git-merged-archive` |
 | Flask 3.0.3, factory, blueprints | `flask-3.mdc` |
 | SQL, `schema.sql`, миграции | `database.mdc` |

--- a/.cursor/rules/git-branches.mdc
+++ b/.cursor/rules/git-branches.mdc
@@ -1,0 +1,40 @@
+---
+description: Naming for task branches — feat/fix/docs and Conventional Commits-like prefixes
+alwaysApply: false
+---
+
+# Git: имена task-веток (flask_blog)
+
+Создание ветки — skill [`git-task-start`](~/.cursor/skills/git-task-start/SKILL.md). Архив после merge — [`git-merged-branches.mdc`](git-merged-branches.mdc).
+
+## Формат
+
+`<тип>/<краткое-kebab-имя>` — одна тема на ветку, латиница, kebab-case.
+
+| Префикс | Когда |
+|---------|--------|
+| `feat/` | новый функционал |
+| `fix/` | исправление багов / угроз безопасности |
+| `docs/` | только документация / Cursor rules / backlog-описание без кода приложения |
+| `chore/` | tooling, CI, зависимости, housekeeping без смены поведения приложения |
+| `refactor/` | рефакторинг без смены внешнего поведения |
+| `test/` | только тесты |
+| `release/` | подготовка релиза (skill `flask-blog-git-release`) |
+| `merged/` | архив после merge — **не** для новой работы |
+
+Остальное — по аналогии с Conventional Commits (`ci/`, `build/`, …), если тип однозначен.
+
+## Примеры
+
+```text
+feat/csrf-protect-forms
+fix/session-fixation
+docs/git-branch-naming
+chore/ruff-config
+refactor/posts-query-helpers
+test/auth-helpers-coverage
+```
+
+## Архив
+
+`feat/foo` → `merged/foo` (префикс типа снимается). То же для `fix/`, `docs/`, …

--- a/.cursor/rules/git-merged-branches.mdc
+++ b/.cursor/rules/git-merged-branches.mdc
@@ -16,6 +16,6 @@ alwaysApply: false
 3. Закончить на integration: `git checkout dev && git pull --ff-only origin dev`
 4. Не PR / не новая работа с head `merged/…`
 
-Имена: `feat/foo` → `merged/foo` (префикс снимается).
+Имена task-веток: [`git-branches.mdc`](git-branches.mdc). Архив: `feat/foo` → `merged/foo` (префикс типа снимается; то же для `fix/`, `docs/`, …).
 
 **Алгоритм (bash + follow-up backlog):** skill [`flask-blog-git-merged-archive`](../skills/flask-blog-git-merged-archive/SKILL.md) — Read и выполнить в том же turn после MERGED. Очистка `Backlog.md` (`done` → sync → удалить секцию) — **сразу merge** docs-PR в том же turn; не оставлять открытый `docs/*-backlog-done`.


### PR DESCRIPTION
## Summary
- Add `git-branches.mdc` with `feat`/`fix`/`docs`/… naming for task branches
- Cross-link from `00-project` and `git-merged-branches`; extend stop-hook prefixes

## Test plan
- [x] Rules-only / no app runtime change


Made with [Cursor](https://cursor.com)